### PR TITLE
Add first test program linked libiopmp

### DIFF
--- a/iopmp_ref_model/Makefile
+++ b/iopmp_ref_model/Makefile
@@ -4,11 +4,15 @@ SRC_DIR  := src
 VERIF    := verif
 TEST_DIR := $(VERIF)/tests
 LIB_DIR  := lib
+LIBIOPMP_DIR := ../libiopmp
+LIBIOPMP     := $(LIBIOPMP_DIR)/build/lib/libiopmp.a
+
 cov =
 COVFLAGS =
 ifeq ($(cov), 1)
 COVFLAGS += -fprofile-arcs -ftest-coverage -lgcov --coverage
 endif
+
 asan =
 ASAN_CFLAGS =
 ASAN_LDFLAGS =
@@ -17,20 +21,34 @@ ASAN_CFLAGS += -fsanitize=address -fno-omit-frame-pointer -O1 -g3
 ASAN_LDFLAGS += -lasan
 endif
 
+libiopmp =
+LIBIOPMP_CFLAGS =
+LIBIOPMP_LDFLAGS =
+LIBIOPMP_PREREQ =
+ifeq ($(libiopmp), 1)
+# Enable coverage analysis
+cov = 1
+LIBIOPMP_CFLAGS += -I$(LIBIOPMP_DIR)/include
+LIBIOPMP_LDFLAGS += $(LIBIOPMP) -lgcov
+# Prerequisite
+LIBIOPMP_PREREQ += $(LIBIOPMP)
+endif
+
 # Compiler and flags
 CC := gcc
-CFLAGS := -Wall -Werror $(COVFLAGS) $(ASAN_CFLAGS) -I./include -Iverif/ -fPIC
-LDFLAGS := -lm $(ASAN_LDFLAGS)
+CFLAGS := -Wall -Werror $(COVFLAGS) $(ASAN_FLAGS) $(LIBIOPMP_CFLAGS) -I./include -Iverif/ -fPIC
+LDFLAGS := -lm $(ASAN_LDFLAGS) $(LIBIOPMP_LDFLAGS)
 
 # Common source files
 COMMON_SOURCES := $(SRC_DIR)/iopmp_reg.c \
-				  $(SRC_DIR)/iopmp_interrupt.c \
+                  $(SRC_DIR)/iopmp_interrupt.c \
                   $(SRC_DIR)/iopmp_rule_analyzer.c \
                   $(SRC_DIR)/iopmp_validate.c \
                   $(SRC_DIR)/iopmp_error_capture.c \
                   $(VERIF)/test_utils.c
 
 # Models and configurations
+ifneq ($(libiopmp),1)
 MODELS := full_model:fullmodel.c:0:0 \
           rapid_k_model:rapidmodel.c:0:1 \
           dynamic_k_model:dynamicmodel.c:0:2 \
@@ -40,6 +58,9 @@ MODELS := full_model:fullmodel.c:0:0 \
           unnamed_model_2:unnamed_model_2.c:2:0 \
           unnamed_model_3:unnamed_model_3.c:2:1 \
           unnamed_model_4:unnamed_model_4.c:2:2
+else
+MODELS := libiopmp_INFO:libiopmp_INFO.c:0:0
+endif
 
 # Targets
 .PHONY: all build run clean
@@ -54,7 +75,7 @@ $(LIB_DIR):
 	mkdir -p $(LIB_DIR)
 
 # Build all models into libraries and executables
-build: $(BIN_DIR) $(LIB_DIR)
+build: $(BIN_DIR) $(LIB_DIR) $(LIBIOPMP_PREREQ)
 	@if [ -z "$(model)" ]; then \
 		echo "Building all models..."; \
 		for entry in $(MODELS); do \
@@ -146,6 +167,7 @@ help:
 	@echo "  sharedLib=1           Build shared libraries instead of static ones"
 	@echo "  cov=1                 Enable code coverage during compilation"
 	@echo "  asan=1                Enable AddressSanitizer"
+	@echo "  libiopmp=1            Build libiopmp test program"
 	@echo ""
 	@echo "Available Models:"
 	@echo "  full_model            SRCMD_FMT = 0, MDCFG_FMT = 0"
@@ -157,6 +179,9 @@ help:
 	@echo "  unnamed_model_2       SRCMD_FMT = 2, MDCFG_FMT = 0"
 	@echo "  unnamed_model_3       SRCMD_FMT = 2, MDCFG_FMT = 1"
 	@echo "  unnamed_model_4       SRCMD_FMT = 2, MDCFG_FMT = 2"
+	@echo ""
+	@echo "Available libiopmp test program:"
+	@echo "  libiopmp_INFO         SRCMD_FMT = 0, MDCFG_FMT = 0"
 	@echo ""
 
 # Clean the binary and library directories

--- a/iopmp_ref_model/verif/tests/libiopmp_INFO.c
+++ b/iopmp_ref_model/verif/tests/libiopmp_INFO.c
@@ -1,0 +1,251 @@
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+#include "libiopmp.h"
+
+/* Override libiopmp IO functions */
+uint32_t io_read32(uintptr_t addr)
+{
+    return read_register(addr, 4);
+}
+
+void io_write32(uintptr_t addr, uint32_t val)
+{
+    return write_register(addr, val, 4);
+}
+
+int main(void)
+{
+    IOPMP_t iopmp = {0};
+    enum iopmp_error ret;
+    uintptr_t addr;
+    uint32_t val_u32;
+    int val_int;
+    bool val_bool;
+
+    FAIL_IF(create_memory(1) < 0)
+
+    // Reset
+    reset_iopmp();
+
+    // Read the registers
+    hwcfg0_t hwcfg0;
+    hwcfg0.raw = read_register(HWCFG0_OFFSET, 4);
+    hwcfg1_t hwcfg1;
+    hwcfg1.raw = read_register(HWCFG1_OFFSET, 4);
+    hwcfg2_t hwcfg2;
+    hwcfg2.raw = read_register(HWCFG2_OFFSET, 4);
+
+    /* Call libiopmp API to initialize this IOPMP instance */
+    START_TEST("Initialize IOPMP");
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    END_TEST();
+
+    /* Start unit tests */
+
+    START_TEST("Get major version of libiopmp");
+    val_int = libiopmp_major_version();
+    FAIL_IF(val_int != LIBIOPMP_VERSION_MAJOR);
+    END_TEST();
+
+    START_TEST("Get minor version of libiopmp");
+    val_int = libiopmp_minor_version();
+    FAIL_IF(val_int != LIBIOPMP_VERSION_MINOR);
+    END_TEST();
+
+    START_TEST("Get extra version of libiopmp");
+    val_int = libiopmp_extra_version();
+    FAIL_IF(val_int != LIBIOPMP_VERSION_EXTRA);
+    END_TEST();
+
+    START_TEST("Check given version is equal to the version of libiopmp");
+    val_bool = libiopmp_check_version(LIBIOPMP_VERSION_MAJOR,
+                                      LIBIOPMP_VERSION_MINOR,
+                                      LIBIOPMP_VERSION_EXTRA);
+    FAIL_IF(val_bool != false);
+    END_TEST();
+
+    START_TEST("Check given major version is greater than version of libiopmp");
+    val_bool = libiopmp_check_version(LIBIOPMP_VERSION_MAJOR + 1,
+                                      LIBIOPMP_VERSION_MINOR,
+                                      LIBIOPMP_VERSION_EXTRA);
+    FAIL_IF(val_bool != true);
+    END_TEST();
+
+    START_TEST("Check given minor version is greater than version of libiopmp");
+    val_bool = libiopmp_check_version(LIBIOPMP_VERSION_MAJOR,
+                                      LIBIOPMP_VERSION_MINOR + 1,
+                                      LIBIOPMP_VERSION_EXTRA);
+    FAIL_IF(val_bool != true);
+    END_TEST();
+
+    START_TEST("Check given extra version is greater than version of libiopmp");
+    val_bool = libiopmp_check_version(LIBIOPMP_VERSION_MAJOR,
+                                      LIBIOPMP_VERSION_MINOR,
+                                      LIBIOPMP_VERSION_EXTRA + 1);
+    FAIL_IF(val_bool != true);
+    END_TEST();
+
+    START_TEST("Check IOPMP has been initialized by libiopmp");
+    val_bool = iopmp_is_initialized(&iopmp);
+    FAIL_IF(val_bool != true);
+    END_TEST();
+
+    START_TEST("Get base address of IOPMP");
+    addr = iopmp_get_base_addr(&iopmp);
+    FAIL_IF(addr != (uintptr_t)0);
+    END_TEST();
+
+    START_TEST("Check MDCFG table format");
+    enum iopmp_mdcfg_fmt mdcfg_fmt = iopmp_get_mdcfg_fmt(&iopmp);
+    FAIL_IF(mdcfg_fmt != (enum iopmp_mdcfg_fmt)hwcfg0.mdcfg_fmt);
+    END_TEST();
+
+    START_TEST("Check SRCMD table format");
+    enum iopmp_srcmd_fmt srcmd_fmt = iopmp_get_srcmd_fmt(&iopmp);
+    FAIL_IF(srcmd_fmt != (enum iopmp_srcmd_fmt)hwcfg0.srcmd_fmt);
+    END_TEST();
+
+    START_TEST("Check IOPMP supports TOR or not");
+    val_bool = iopmp_get_support_tor(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.tor_en);
+    END_TEST();
+
+    START_TEST("Check IOPMP supports SPS extension or not");
+    val_bool = iopmp_get_support_sps(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.sps_en);
+    END_TEST();
+
+    START_TEST("Check IOPMP supports user customized attributes or not");
+    val_bool = iopmp_get_support_user_entry_cfg(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.user_cfg_en);
+    END_TEST();
+
+    START_TEST("Check IOPMP supports programmable prio_entry or not");
+    val_bool = iopmp_get_support_programmable_prio_entry(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.prient_prog);
+    END_TEST();
+
+    START_TEST("Check IOPMP supports tagging a new RRID or not");
+    val_bool = iopmp_get_support_rrid_transl(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.rrid_transl_en);
+    END_TEST();
+
+    START_TEST("Check IOPMP rrid_transl is programmable or not");
+    val_bool = iopmp_get_rrid_transl_prog(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.rrid_transl_prog);
+    END_TEST();
+
+    START_TEST("Check IOPMP implements the check of instruction fetch or not");
+    val_bool = iopmp_get_support_chk_x(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.chk_x);
+    END_TEST();
+
+    START_TEST("Check IOPMP always fails on an instruction fetch or not");
+    val_bool = iopmp_get_no_x(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.no_x);
+    END_TEST();
+
+    START_TEST("Check IOPMP always fails on an write accesses or not");
+    val_bool = iopmp_get_no_w(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.no_w);
+    END_TEST();
+
+    START_TEST("Check IOPMP implements stall-related features or not");
+    val_bool = iopmp_get_support_stall(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.stall_en);
+    END_TEST();
+
+    START_TEST("Check IOPMP implements interrupt suppression per entry or not");
+    val_bool = iopmp_get_support_peis(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.peis);
+    END_TEST();
+
+    START_TEST("Check IOPMP implements the error suppression per entry or not");
+    val_bool = iopmp_get_support_pees(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.pees);
+    END_TEST();
+
+    START_TEST("Check IOPMP implements Multi Faults Record Extension or not");
+    val_bool = iopmp_get_support_mfr(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.mfr_en);
+    END_TEST();
+
+    START_TEST("Get the supported number of MD");
+    val_u32 = iopmp_get_md_num(&iopmp);
+    FAIL_IF(val_u32 != hwcfg0.md_num);
+    END_TEST();
+
+    START_TEST("Check IOPMP implements ENTRY_ADDRH(i) and ERR_MSIADDRH");
+    val_bool = iopmp_get_addrh_en(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.addrh_en);
+    END_TEST();
+
+    START_TEST("Check IOPMP checks transactions by default");
+    val_bool = iopmp_get_enable(&iopmp);
+    FAIL_IF(val_bool != hwcfg0.enable);
+    END_TEST();
+
+    START_TEST("Get the supported number of RRID");
+    val_u32 = iopmp_get_rrid_num(&iopmp);
+    FAIL_IF(val_u32 != hwcfg1.rrid_num);
+    END_TEST();
+
+    START_TEST("Get the supported number of entries");
+    val_u32 = iopmp_get_entry_num(&iopmp);
+    FAIL_IF(val_u32 != hwcfg1.entry_num);
+    END_TEST();
+
+    START_TEST("Get the number of entries matched with priority");
+    val_u32 = iopmp_get_prio_entry_num(&iopmp);
+    FAIL_IF(val_u32 != hwcfg2.prio_entry);
+    END_TEST();
+
+    START_TEST("Get the RRID tagged to outgoing transactions");
+    val_u32 = iopmp_get_rrid_transl(&iopmp);
+    FAIL_IF(val_u32 != hwcfg2.rrid_transl);
+    END_TEST();
+
+    START_TEST("Get vendor ID correctly");
+    ret = iopmp_get_vendor_id(&iopmp, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 1);
+    END_TEST();
+
+    START_TEST("Get vendor ID with invalid argument");
+    ret = iopmp_get_vendor_id(&iopmp, NULL);
+    FAIL_IF(ret != IOPMP_ERR_INVALID_PARAMETER);
+    END_TEST();
+
+    START_TEST("Get specification version correctly");
+    ret = iopmp_get_specver(&iopmp, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 1);
+    END_TEST();
+
+    START_TEST("Get specification version with invalid argument");
+    ret = iopmp_get_specver(&iopmp, NULL);
+    FAIL_IF(ret != IOPMP_ERR_INVALID_PARAMETER);
+    END_TEST();
+
+    START_TEST("Get the user-defined implementation ID correctly");
+    ret = iopmp_get_impid(&iopmp, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 0);
+    END_TEST();
+
+    START_TEST("Get the user-defined implementation ID with invalid argument");
+    ret = iopmp_get_impid(&iopmp, NULL);
+    FAIL_IF(ret != IOPMP_ERR_INVALID_PARAMETER);
+    END_TEST();
+
+    START_TEST("Get base address of IOPMP entry array");
+    addr = iopmp_get_base_addr_entry_array(&iopmp);
+    FAIL_IF(addr != (uintptr_t)ENTRY_OFFSET);
+    END_TEST();
+
+    return 0;
+}

--- a/libiopmp/Makefile
+++ b/libiopmp/Makefile
@@ -39,7 +39,6 @@ CFLAGS	+= -fno-strict-aliasing -ffunction-sections -fdata-sections
 CFLAGS	+= -fno-omit-frame-pointer -fno-optimize-sibling-calls
 CFLAGS	+= -fno-asynchronous-unwind-tables -fno-unwind-tables
 CFLAGS	+= -I$(src_dir) -I$(inc_dir)
-CFLAGS	+= --coverage
 
 ifeq ($(DEBUG),y)
 CFLAGS	+= -O0 -DDEBUG
@@ -48,6 +47,7 @@ CFLAGS	+= -O2
 endif
 
 ifeq ($(CFG_IOPMP_REF_MODEL),y)
+CFLAGS	+= --coverage
 CFLAGS	+= -DENABLE_IO_WEAK_FUNCTIONS
 endif
 


### PR DESCRIPTION
This PR adds first test program linked with `libiopmp` and invokes `libiopmp` APIs to get IOPMP configurations.
We will add more test program later.