### PR TITLE
Reference Model: Some fixes and improvements for rule analyzer

### DIFF
--- a/iopmp_ref_model/include/iopmp.h
+++ b/iopmp_ref_model/include/iopmp.h
@@ -107,10 +107,31 @@ typedef struct iopmp_cfg_t {
     bool imp_msi;                       // IOPMP implements message-signaled interrupts (MSI)
 } iopmp_cfg_t;
 
+// Enumerates specific match and error statuses for transactions
+typedef enum {
+    ENTRY_NOTMATCH,                     // Entry doesn't match any byte of a transation
+    ENTRY_PARTIAL_MATCH,                // Entry matches partial bytes of a transation
+    ENTRY_MATCH,                        // Entry matches all bytes of a transation
+    ENTRY_MATCH_NOTGRANT,               // Entry matches all bytes of a transaction, but doesn't grant transaction permission
+    ENTRY_MATCH_GRANT,                  // Entry matches all bytes of a transaction and grants transaction permission
+} iopmpMatchStatus_t;
+
+// Enumerates the type of violation for transactions
+typedef enum {
+    NO_ERROR                = 0x00,     // No error
+    ILLEGAL_READ_ACCESS     = 0x01,     // Illegal read access attempted
+    ILLEGAL_WRITE_ACCESS    = 0x02,     // Illegal write access attempted
+    ILLEGAL_INSTR_FETCH     = 0x03,     // Illegal instruction fetch attempted
+    PARTIAL_HIT_ON_PRIORITY = 0x04,     // Partial hit on a priority entry
+    NOT_HIT_ANY_RULE        = 0x05,     // No rule matched the transaction
+    UNKNOWN_RRID            = 0x06,     // Unknown requester ID in transaction
+    STALLED_TRANSACTION     = 0x07,     // Error due to a stalled transaction
+} iopmpErrorType_t;
+
 uint8_t write_memory(uint64_t *data, uint64_t addr, uint32_t size);
 
 // Function Declarations: Core IOPMP operations
-iopmpMatchStatus_t iopmpRuleAnalyzer(iopmp_dev_t *iopmp, iopmp_trans_req_t trans_req, uint64_t prev_iopmpaddr, uint64_t iopmpaddr, entry_cfg_t iopmpcfg, uint8_t md, int is_priority);
+iopmpMatchStatus_t iopmpRuleAnalyzer(iopmp_dev_t *iopmp, iopmp_trans_req_t trans_req, uint64_t prev_iopmpaddr, uint64_t iopmpaddr, entry_cfg_t iopmpcfg, uint8_t md);
 void errorCapture(iopmp_dev_t *iopmp, perm_type_e trans_type, uint8_t error_type, uint16_t rrid, uint16_t entry_id, uint64_t err_addr, uint8_t *intrpt);
 void generate_interrupt(iopmp_dev_t *iopmp, uint8_t *intrpt);
 

--- a/iopmp_ref_model/include/iopmp_req_rsp.h
+++ b/iopmp_ref_model/include/iopmp_req_rsp.h
@@ -62,7 +62,7 @@ typedef struct __attribute__((__packed__)) {
     uint32_t rrid;          // Requester ID
     uint8_t  user;          // User mode indicator
     uint8_t  rrid_stalled;  // Requester ID stall status
-    uint16_t rrid_transl;
+    uint16_t rrid_transl;   // The RRID tagged to outgoing transactions
     status_e status;        // Transaction status (success or error)
 } iopmp_trans_rsp_t;
 

--- a/iopmp_ref_model/include/iopmp_req_rsp.h
+++ b/iopmp_ref_model/include/iopmp_req_rsp.h
@@ -44,20 +44,6 @@ typedef enum {
     IOPMP_ERROR   = 1   // Transaction encountered an error
 } status_e;
 
-// Enumerates specific match and error statuses for transactions
-typedef enum {
-    NO_ERROR               = 0x00,  // No error
-    ILLEGAL_READ_ACCESS    = 0x01,  // Illegal read access attempted
-    ILLEGAL_WRITE_ACCESS   = 0x02,  // Illegal write access attempted
-    ILLEGAL_INSTR_FETCH    = 0x03,  // Illegal instruction fetch attempted
-    PARTIAL_HIT_ON_PRIORITY= 0x04,  // Partial hit on a priority entry
-    NOT_HIT_ANY_RULE       = 0x05,  // No rule matched the transaction
-    UNKNOWN_RRID           = 0x06,  // Unknown requester ID in transaction
-    STALLED_TRANSACTION    = 0x07,  // Error due to a stalled transaction
-    ENTRY_MATCH            = 0x10,  // Entry matched in access control
-    ENTRY_NOTMATCH         = 0x11   // No matching entry found
-} iopmpMatchStatus_t;
-
 // Structure for IOPMP transaction responses
 typedef struct __attribute__((__packed__)) {
     uint32_t rrid;          // Requester ID

--- a/iopmp_ref_model/include/iopmp_req_rsp.h
+++ b/iopmp_ref_model/include/iopmp_req_rsp.h
@@ -46,6 +46,7 @@ typedef enum {
 
 // Enumerates specific match and error statuses for transactions
 typedef enum {
+    NO_ERROR               = 0x00,  // No error
     ILLEGAL_READ_ACCESS    = 0x01,  // Illegal read access attempted
     ILLEGAL_WRITE_ACCESS   = 0x02,  // Illegal write access attempted
     ILLEGAL_INSTR_FETCH    = 0x03,  // Illegal instruction fetch attempted

--- a/iopmp_ref_model/src/iopmp_rule_analyzer.c
+++ b/iopmp_ref_model/src/iopmp_rule_analyzer.c
@@ -200,10 +200,6 @@ static iopmpMatchStatus_t iopmpCheckPerms(iopmp_dev_t *iopmp, uint16_t rrid, per
 iopmpMatchStatus_t iopmpRuleAnalyzer(iopmp_dev_t *iopmp, iopmp_trans_req_t trans_req, uint64_t prev_iopmpaddr, uint64_t iopmpaddr, entry_cfg_t iopmpcfg, uint8_t md, int is_priority) {
     iopmpMatchStatus_t match_status = ENTRY_MATCH;  // Default to full match
     uint64_t start_addr, end_addr;
-    bool no_w  = iopmp->reg_file.hwcfg3.no_w;     // Write restriction
-    bool no_x  = iopmp->reg_file.hwcfg3.no_x;     // Execute restriction
-    bool chk_x = iopmp->reg_file.hwcfg2.chk_x;    // Execute permission check enable
-    if ((no_w && (trans_req.perm == WRITE_ACCESS)) || (no_x && (trans_req.perm == INSTR_FETCH) && chk_x)) { return ENTRY_NOTMATCH; }
 
     // Set up the address range; if range setup fails, return not matched
     if (iopmpAddrRange(&start_addr, &end_addr, prev_iopmpaddr, iopmpaddr, iopmpcfg)) { return ENTRY_NOTMATCH; }

--- a/iopmp_ref_model/src/iopmp_validate.c
+++ b/iopmp_ref_model/src/iopmp_validate.c
@@ -65,8 +65,7 @@ void iopmp_validate_access(iopmp_dev_t *iopmp, iopmp_trans_req_t *trans_req, iop
 
     // IOPMP always allow the transaction when enable = 0
     if (!iopmp->reg_file.hwcfg0.enable) {
-        iopmp_trans_rsp->status = IOPMP_SUCCESS;
-        return ;
+        goto pass_checks;
     }
 
     // Tag a new RRID which represents that the transaction has been checked.
@@ -149,8 +148,7 @@ void iopmp_validate_access(iopmp_dev_t *iopmp, iopmp_trans_req_t *trans_req, iop
             iopmpMatchStatus = iopmpRuleAnalyzer(iopmp, *trans_req, prev_addr, curr_addr, entry_cfg, cur_md, is_priority_entry);
 
             if (iopmpMatchStatus == ENTRY_MATCH) {
-                iopmp_trans_rsp->status = IOPMP_SUCCESS;
-                return ;  // Return on successful match
+                goto pass_checks;
             } else if (iopmpMatchStatus != ENTRY_NOTMATCH) {
                 if (!is_priority_entry) {
                     if (iopmp->imp_error_capture) {
@@ -179,6 +177,10 @@ void iopmp_validate_access(iopmp_dev_t *iopmp, iopmp_trans_req_t *trans_req, iop
     error_type = nonPrioRuleStatus;
     error_eid  = nonPrioRuleNum;
     goto stop_and_report_fault;
+
+pass_checks:
+    iopmp_trans_rsp->status = IOPMP_SUCCESS;
+    return;
 
 stop_and_report_fault:
     // If IOPMP implements error capture feature, IOPMP triggers error capture

--- a/iopmp_ref_model/src/iopmp_validate.c
+++ b/iopmp_ref_model/src/iopmp_validate.c
@@ -191,11 +191,16 @@ void iopmp_validate_access(iopmp_dev_t *iopmp, iopmp_trans_req_t *trans_req, iop
     }
 
     // If No rule hits, enable error suppression based on global error suppression bit
-    if (nonPrioRuleStatus == NOT_HIT_ANY_RULE) { iopmp->error_suppress = iopmp->reg_file.err_cfg.rs; }
-    else { iopmp->error_suppress = nonPrioErrorSup; iopmp->intrpt_suppress = nonPrioIntrSup; }
+    if (iopmp->reg_file.hwcfg2.non_prio_en) {
+        if (nonPrioRuleStatus == NOT_HIT_ANY_RULE) { iopmp->error_suppress = iopmp->reg_file.err_cfg.rs; }
+        else { iopmp->error_suppress = nonPrioErrorSup; iopmp->intrpt_suppress = nonPrioIntrSup; }
 
-    error_type = nonPrioRuleStatus;
-    error_eid  = nonPrioRuleNum;
+        error_type = nonPrioRuleStatus;
+        error_eid  = nonPrioRuleNum;
+    } else {
+        iopmp->error_suppress = iopmp->reg_file.err_cfg.rs;
+        error_type = NOT_HIT_ANY_RULE;
+    }
     goto stop_and_report_fault;
 
 pass_checks:

--- a/iopmp_ref_model/src/iopmp_validate.c
+++ b/iopmp_ref_model/src/iopmp_validate.c
@@ -38,9 +38,7 @@ void iopmp_validate_access(iopmp_dev_t *iopmp, iopmp_trans_req_t *trans_req, iop
     iopmp_trans_rsp->rrid_stalled = 0;
     iopmp_trans_rsp->user         = 0;
     iopmp_trans_rsp->status       = IOPMP_ERROR;
-    if (iopmp->reg_file.hwcfg3.rrid_transl_en) {
-        iopmp_trans_rsp->rrid_transl = iopmp->reg_file.hwcfg3.rrid_transl;
-    }
+    iopmp_trans_rsp->rrid_transl  = trans_req->rrid;
 
     // Check to block invalid combination
     if (trans_req->perm == INSTR_FETCH && trans_req->is_amo) {
@@ -67,6 +65,13 @@ void iopmp_validate_access(iopmp_dev_t *iopmp, iopmp_trans_req_t *trans_req, iop
         iopmp_trans_rsp->status = IOPMP_SUCCESS;
         return ;
     }
+
+    // Tag a new RRID which represents that the transaction has been checked.
+    // The RRID translation takes effect when IOPMP checker is enabled.
+    if (iopmp->reg_file.hwcfg3.rrid_transl_en) {
+        iopmp_trans_rsp->rrid_transl = iopmp->reg_file.hwcfg3.rrid_transl;
+    }
+
     // Check for valid RRID; if invalid, capture error and return
     if (trans_req->rrid >= iopmp->reg_file.hwcfg1.rrid_num) {
         // Initially, check for global error suppression


### PR DESCRIPTION
Summary:
- The `rrid_transl` takes effect only when IOPMP has been enabled.
- Move `no_w` and `no_x` checks from entry level to top level (`iopmp_validate_access()`).
- Reduce duplicated code to improve maintenance.
- Refine the rule analyzer and matching logics


The biggest change in this PR is to clarify the meaning of "match". From the spec:
An entry qualifies as a matching entry for an incoming transaction if:
- Its region covers any byte of the transaction,
- It is associated with the RRID carried by the transaction; and
- It holds the highest priority among entries that meet the previous criteria.

Technically speaking, **"match"** doesn't mean that the entry also grants transaction permission.
The model should distinguish between the following two cases:
- Entry matches the transaction, and grants transaction permission
- Entry matches the transaction, but doesn't grant transaction permission

We add more `enum` (MATCH & GRANT) to describe the aforementioned cases.