### PR TITLE
Reference Model: Some fixes and improvements for chk_x and source enforcement model

### DIFF
--- a/iopmp_ref_model/include/iopmp.h
+++ b/iopmp_ref_model/include/iopmp.h
@@ -107,13 +107,11 @@ typedef struct iopmp_cfg_t {
     bool imp_msi;                       // IOPMP implements message-signaled interrupts (MSI)
 } iopmp_cfg_t;
 
-// Enumerates specific match and error statuses for transactions
+// Enumerates specific match statuses for transactions
 typedef enum {
     ENTRY_NOTMATCH,                     // Entry doesn't match any byte of a transation
     ENTRY_PARTIAL_MATCH,                // Entry matches partial bytes of a transation
     ENTRY_MATCH,                        // Entry matches all bytes of a transation
-    ENTRY_MATCH_NOTGRANT,               // Entry matches all bytes of a transaction, but doesn't grant transaction permission
-    ENTRY_MATCH_GRANT,                  // Entry matches all bytes of a transaction and grants transaction permission
 } iopmpMatchStatus_t;
 
 // Enumerates the type of violation for transactions
@@ -128,10 +126,30 @@ typedef enum {
     STALLED_TRANSACTION     = 0x07,     // Error due to a stalled transaction
 } iopmpErrorType_t;
 
+// The information the rule analyzer needs
+typedef struct iopmp_rule_analyzer_input_t {
+    uint16_t rrid;
+    uint64_t prev_iopmpaddr;
+    uint64_t iopmpaddr;
+    entry_cfg_t iopmpcfg;
+    uint64_t trans_start;
+    uint64_t trans_end;
+    perm_type_e perm;
+    bool is_amo;
+    uint8_t md;
+} iopmp_rule_analyzer_input_t;
+
+// The output of the rule analyzer
+typedef struct iopmp_rule_analyzer_output_t {
+    iopmpMatchStatus_t match_status;
+    bool grant_perm;
+} iopmp_rule_analyzer_output_t;
+
 uint8_t write_memory(uint64_t *data, uint64_t addr, uint32_t size);
 
 // Function Declarations: Core IOPMP operations
-iopmpMatchStatus_t iopmpRuleAnalyzer(iopmp_dev_t *iopmp, iopmp_trans_req_t trans_req, uint64_t prev_iopmpaddr, uint64_t iopmpaddr, entry_cfg_t iopmpcfg, uint8_t md);
+void iopmpRuleAnalyzer(iopmp_dev_t *iopmp, iopmp_rule_analyzer_input_t *input,
+                       iopmp_rule_analyzer_output_t *output);
 void errorCapture(iopmp_dev_t *iopmp, perm_type_e trans_type, uint8_t error_type, uint16_t rrid, uint16_t entry_id, uint64_t err_addr, uint8_t *intrpt);
 void generate_interrupt(iopmp_dev_t *iopmp, uint8_t *intrpt);
 

--- a/iopmp_ref_model/src/iopmp_reg.c
+++ b/iopmp_ref_model/src/iopmp_reg.c
@@ -98,6 +98,8 @@ int reset_iopmp(iopmp_dev_t *iopmp, iopmp_cfg_t *cfg)
 
     // Hardware Configuration
     iopmp->reg_file.hwcfg0.enable           = cfg->enable;
+    iopmp->reg_file.hwcfg0.HWCFG2_en        = 1;    // HWCFG2 is always implemented by reference model
+    iopmp->reg_file.hwcfg0.HWCFG3_en        = 1;    // HWCFG3 is always implemented by reference model
     iopmp->reg_file.hwcfg0.md_num           = cfg->md_num;
     iopmp->reg_file.hwcfg0.addrh_en         = cfg->addrh_en;
     iopmp->reg_file.hwcfg0.tor_en           = cfg->tor_en;
@@ -114,8 +116,6 @@ int reset_iopmp(iopmp_dev_t *iopmp, iopmp_cfg_t *cfg)
     iopmp->reg_file.hwcfg2.sps_en           = cfg->sps_en;
     iopmp->reg_file.hwcfg2.stall_en         = cfg->stall_en;
     iopmp->reg_file.hwcfg2.mfr_en           = cfg->mfr_en;
-    /* Set HWCFG2_en if HWCFG2 is not zero */
-    iopmp->reg_file.hwcfg0.HWCFG2_en        = (iopmp->reg_file.hwcfg2.raw) != 0 ? true : false;
 
     iopmp->reg_file.hwcfg3.mdcfg_fmt        = cfg->mdcfg_fmt;
     iopmp->reg_file.hwcfg3.srcmd_fmt        = cfg->srcmd_fmt;
@@ -129,8 +129,6 @@ int reset_iopmp(iopmp_dev_t *iopmp, iopmp_cfg_t *cfg)
         iopmp->reg_file.hwcfg3.rrid_transl_prog = cfg->rrid_transl_prog;
         iopmp->reg_file.hwcfg3.rrid_transl      = cfg->rrid_transl;
     }
-    /* Set HWCFG3_en if HWCFG3 is not zero */
-    iopmp->reg_file.hwcfg0.HWCFG3_en        = (iopmp->reg_file.hwcfg3.raw) != 0 ? true : false;
 
     iopmp->reg_file.entryoffset.offset      = cfg->entryoffset;
 

--- a/iopmp_ref_model/src/iopmp_rule_analyzer.c
+++ b/iopmp_ref_model/src/iopmp_rule_analyzer.c
@@ -171,12 +171,8 @@ static bool iopmpCheckPerms(iopmp_dev_t *iopmp, uint16_t rrid, perm_type_e req_p
                 iopmp->error_suppress  = iopmpcfg.sexe | iopmp->reg_file.err_cfg.rs;
             }
             return execute_allowed;
-        } else if (read_allowed) {
-            return read_allowed;   // Grant Execute permission via Read fallback
         }
-        iopmp->intrpt_suppress = iopmpcfg.sixe;
-        iopmp->error_suppress  = iopmpcfg.sexe | iopmp->reg_file.err_cfg.rs;
-        return false;
+        return false;   // Instruction fetch check not implemented
 
     default:
         return false;   // Default case for invalid permission request

--- a/iopmp_ref_model/verif/tests/fullmodel.c
+++ b/iopmp_ref_model/verif/tests/fullmodel.c
@@ -1047,7 +1047,7 @@ int main()
     configure_srcmd_n(&iopmp, SRCMD_EN, 0, 0x02, 4);
     configure_srcmd_n(&iopmp, SRCMD_R, 0, 0x02, 4);
     configure_srcmd_n(&iopmp, SRCMD_W, 0, 0x02, 4);
-    configure_mdcfg_n(0, 2, 4);
+    configure_mdcfg_n(&iopmp, 0, 2, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 0, 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 0, (NAPOT | W | R), 4);
     set_hwcfg0_enable(&iopmp);


### PR DESCRIPTION
Summary:
- Simplify the settings of RRID and MD for Source-Enforcement model
- Modularize the interface of the rule analyzer.
- Fixes https://github.com/riscv-non-isa/iopmp-spec/issues/191 by treating instruction fetch transaction as read access when `chk_x=0`.

@gullahmed1 Please review this PR!