### PR TITLE
Reference Model: Refine interrupt and bus error suppression

### DIFF
--- a/iopmp_ref_model/include/iopmp.h
+++ b/iopmp_ref_model/include/iopmp.h
@@ -60,8 +60,6 @@ typedef struct iopmp_dev_t {
     iopmp_regs_t reg_file;              // Register file for IOPMP
     iopmp_entries_t iopmp_entries;      // IOPMP entry table
     err_mfrs_t err_svs;                 // Error status vector
-    int intrpt_suppress;                // Set when interrupt is suppressed
-    int error_suppress;                 // Set when error is suppressed
     int rrid_stall[IOPMP_MAX_RRID_NUM]; // Stall status array for requester IDs
     int stall_cntr;                     // Counts stalled transactions
     bool imp_mdlck;                     // IOPMP implements the Memory Domain Lock (MDLCK) feature
@@ -158,7 +156,9 @@ uint8_t write_memory(uint64_t *data, uint64_t addr, uint32_t size);
 // Function Declarations: Core IOPMP operations
 void iopmpRuleAnalyzer(iopmp_dev_t *iopmp, iopmp_rule_analyzer_input_t *input,
                        iopmp_rule_analyzer_output_t *output);
-void errorCapture(iopmp_dev_t *iopmp, perm_type_e trans_type, uint8_t error_type, uint16_t rrid, uint16_t entry_id, uint64_t err_addr, uint8_t *intrpt);
-void generate_interrupt(iopmp_dev_t *iopmp, uint8_t *intrpt);
+void errorCapture(iopmp_dev_t *iopmp, perm_type_e trans_type, uint8_t error_type,
+                  uint16_t rrid, uint16_t entry_id, uint64_t err_addr,
+                  bool gen_intrpt, bool gen_buserr, uint8_t *intrpt);
+void generate_interrupt(iopmp_dev_t *iopmp, bool gen_intrpt, uint8_t *intrpt);
 
 #endif // IOPMP_H

--- a/iopmp_ref_model/include/iopmp.h
+++ b/iopmp_ref_model/include/iopmp.h
@@ -145,6 +145,12 @@ typedef struct iopmp_rule_analyzer_input_t {
 typedef struct iopmp_rule_analyzer_output_t {
     iopmpMatchStatus_t match_status;
     bool grant_perm;
+    bool sie;           // When per-entry interrupt suppression is supported,
+                        // this signal indicates the matched entry suppresses
+                        // the interrupt for requested permission.
+    bool see;           // When per-entry bus error suppression is supported,
+                        // this signal indicates the matched entry suppresses
+                        // the bus error for requested permission.
 } iopmp_rule_analyzer_output_t;
 
 uint8_t write_memory(uint64_t *data, uint64_t addr, uint32_t size);

--- a/iopmp_ref_model/src/iopmp_validate.c
+++ b/iopmp_ref_model/src/iopmp_validate.c
@@ -215,6 +215,8 @@ void iopmp_validate_access(iopmp_dev_t *iopmp, iopmp_trans_req_t *trans_req, iop
             /* Reset output information */
             rule_analyzer_o.match_status = ENTRY_NOTMATCH;
             rule_analyzer_o.grant_perm   = false;
+            rule_analyzer_o.sie          = false;
+            rule_analyzer_o.see          = false;
 
             // Analyze entry for matching and permission granting
             iopmpRuleAnalyzer(iopmp, &rule_analyzer_i, &rule_analyzer_o);

--- a/iopmp_ref_model/verif/tests/compactmodel.c
+++ b/iopmp_ref_model/verif/tests/compactmodel.c
@@ -524,7 +524,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 
@@ -541,7 +541,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 

--- a/iopmp_ref_model/verif/tests/dynamicmodel.c
+++ b/iopmp_ref_model/verif/tests/dynamicmodel.c
@@ -761,7 +761,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 
@@ -780,7 +780,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 

--- a/iopmp_ref_model/verif/tests/fullmodel.c
+++ b/iopmp_ref_model/verif/tests/fullmodel.c
@@ -855,7 +855,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 
@@ -875,7 +875,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 

--- a/iopmp_ref_model/verif/tests/isolationmodel.c
+++ b/iopmp_ref_model/verif/tests/isolationmodel.c
@@ -561,7 +561,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 
@@ -579,7 +579,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 

--- a/iopmp_ref_model/verif/tests/rapidmodel.c
+++ b/iopmp_ref_model/verif/tests/rapidmodel.c
@@ -763,7 +763,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 
@@ -782,7 +782,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 

--- a/iopmp_ref_model/verif/tests/unnamed_model_1.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_1.c
@@ -511,7 +511,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 
@@ -528,7 +528,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 

--- a/iopmp_ref_model/verif/tests/unnamed_model_2.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_2.c
@@ -598,7 +598,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 
@@ -617,7 +617,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 

--- a/iopmp_ref_model/verif/tests/unnamed_model_3.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_3.c
@@ -501,7 +501,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 
@@ -519,7 +519,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 

--- a/iopmp_ref_model/verif/tests/unnamed_model_4.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_4.c
@@ -483,7 +483,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 
@@ -501,7 +501,7 @@ int main()
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
-    error_record_chk(&iopmp, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    error_record_chk(&iopmp, NO_ERROR, INSTR_FETCH, 360, 0);
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
     END_TEST();)
 


### PR DESCRIPTION
The model left out a condition to suppress interrupt.
This PR fixes the bug and https://github.com/riscv-non-isa/iopmp-spec/issues/198.