### PR TITLE
Reference Model: Fix candidate of ERR_REQID.eid for non-priority entries

### DIFF
--- a/iopmp_ref_model/src/iopmp_validate.c
+++ b/iopmp_ref_model/src/iopmp_validate.c
@@ -257,9 +257,18 @@ void iopmp_validate_access(iopmp_dev_t *iopmp, iopmp_trans_req_t *trans_req, iop
                         gen_buserr_nonPrio = (gen_buserr_nonPrio || !rule_analyzer_o.see);
                     }
 
-                    if (firstIllegalAccess) {
-                        nonPrioRuleStatus = perm_to_etype(trans_perm);
-                        nonPrioRuleNum    = cur_entry;
+                    nonPrioRuleStatus = perm_to_etype(trans_perm);
+                    // For an illegal transaction matching multiple non-priority
+                    // entries, if the interrupt is triggered or the bus error
+                    // response is returned, ERR_REQID.eid stores the index of
+                    // any of them.
+                    // Here the models determines if this entry could be
+                    // candidate of ERR_REQID.eid field. The matched entry could
+                    // be candidate if it can generate error report.
+                    if (firstIllegalAccess &&
+                        ((iopmp->reg_file.err_cfg.ie && !rule_analyzer_o.sie) ||
+                         (!iopmp->reg_file.err_cfg.rs && !rule_analyzer_o.see))) {
+                        nonPrioRuleNum = cur_entry;
                         firstIllegalAccess = 0;
                     }
                     continue;


### PR DESCRIPTION
The spec says that a non-priority entry can be stored into ERR_REQID.eid when it matches the transaction but does not grant the permissions and it can generate error report.

Fix https://github.com/riscv-non-isa/iopmp-spec/issues/210.