### PR TITLE
Reference Model & libiopmp: Add libiopmp full model tests and some improvements

### DIFF
--- a/iopmp_ref_model/Makefile
+++ b/iopmp_ref_model/Makefile
@@ -59,7 +59,8 @@ MODELS := full_model:fullmodel.c \
           unnamed_model_3:unnamed_model_3.c \
           unnamed_model_4:unnamed_model_4.c
 else
-MODELS := libiopmp_INFO:libiopmp_INFO.c
+MODELS := libiopmp_INFO:libiopmp_INFO.c \
+          libiopmp_full_model:libiopmp_fullmodel.c
 endif
 
 # Targets
@@ -167,8 +168,9 @@ help:
 	@echo "  unnamed_model_3       SRCMD_FMT = 2, MDCFG_FMT = 1"
 	@echo "  unnamed_model_4       SRCMD_FMT = 2, MDCFG_FMT = 2"
 	@echo ""
-	@echo "Available libiopmp test program:"
+	@echo "Available libiopmp test programs:"
 	@echo "  libiopmp_INFO         SRCMD_FMT = 0, MDCFG_FMT = 0"
+	@echo "  libiopmp_full_model   SRCMD_FMT = 0, MDCFG_FMT = 0"
 	@echo ""
 
 # Clean the binary and library directories

--- a/iopmp_ref_model/verif/tests/compactmodel.c
+++ b/iopmp_ref_model/verif/tests/compactmodel.c
@@ -405,10 +405,8 @@ int main()
     receiver_port(32, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     configure_entry_n(&iopmp, ENTRY_ADDR, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 74, 4);
     configure_entry_n(&iopmp, ENTRY_CFG, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 0x1C, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 90, 4);
     configure_entry_n(&iopmp, ENTRY_CFG, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 0x18, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 90, 4);
     configure_entry_n(&iopmp, ENTRY_CFG, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 0x1C, 4);
     set_hwcfg0_enable(&iopmp);

--- a/iopmp_ref_model/verif/tests/dynamicmodel.c
+++ b/iopmp_ref_model/verif/tests/dynamicmodel.c
@@ -512,12 +512,10 @@ int main()
     configure_srcmd_n(&iopmp, SRCMD_X, 31, 0x10, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 3), 74, 4); // (300 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 3), 0x1C, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_srcmd_n(&iopmp, SRCMD_EN, 32, 0x20, 4);
     configure_srcmd_n(&iopmp, SRCMD_X, 32, 0x20, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 4), 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 4), 0x18, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 4), 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 4), 0x1C, 4);
     set_hwcfg0_enable(&iopmp);

--- a/iopmp_ref_model/verif/tests/fullmodel.c
+++ b/iopmp_ref_model/verif/tests/fullmodel.c
@@ -581,13 +581,11 @@ int main()
     configure_mdcfg_n(&iopmp, 3, 17, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 1, 74, 4); // (300 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 1, (NAPOT | X), 4);
-    set_hwcfg0_enable(&iopmp);
     configure_srcmd_n(&iopmp, SRCMD_EN, 32, 0x20, 4);
     configure_srcmd_n(&iopmp, SRCMD_X, 32, 0x20, 4);
     configure_mdcfg_n(&iopmp, 4, 25, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 18, 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 18, (NAPOT), 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, 20, 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 20, (NAPOT | X), 4);
     set_hwcfg0_enable(&iopmp);

--- a/iopmp_ref_model/verif/tests/isolationmodel.c
+++ b/iopmp_ref_model/verif/tests/isolationmodel.c
@@ -378,11 +378,9 @@ int main()
     configure_mdcfg_n(&iopmp, 3, 17, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 1, 74, 4);    // (300 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 1, (NAPOT | X), 4);
-    set_hwcfg0_enable(&iopmp);
     configure_mdcfg_n(&iopmp, 32, 25, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 18, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 18, (NAPOT), 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, 20, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 20, (NAPOT | X), 4);
     set_hwcfg0_enable(&iopmp);

--- a/iopmp_ref_model/verif/tests/libiopmp_fullmodel.c
+++ b/iopmp_ref_model/verif/tests/libiopmp_fullmodel.c
@@ -1,0 +1,2236 @@
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+#include "libiopmp.h"
+
+// Declarations
+iopmp_trans_req_t iopmp_trans_req;
+iopmp_trans_rsp_t iopmp_trans_rsp;
+err_info_t err_info_temp;
+
+// Create IOPMP instance
+iopmp_dev_t iopmp_dev = {0};
+iopmp_cfg_t cfg = {0};
+uint8_t intrpt;
+
+/* Override libiopmp IO functions */
+uint32_t io_read32(uintptr_t addr)
+{
+    return read_register(&iopmp_dev, addr, 4);
+}
+
+void io_write32(uintptr_t addr, uint32_t val)
+{
+    return write_register(&iopmp_dev, addr, val, 4);
+}
+
+int main(void)
+{
+    IOPMP_t iopmp = {0};
+    enum iopmp_error ret;
+    uint32_t val_u32;
+    uint64_t val_u64;
+    struct iopmp_entry entries[8] = {0};
+
+    FAIL_IF(create_memory(1) < 0)
+
+    // Configure and reset IOPMP device
+    cfg.vendor = 1;
+    cfg.specver = 1;
+    cfg.impid = 0;
+    cfg.no_err_rec = false;
+    cfg.md_num = 63;
+    cfg.addrh_en = true;
+    cfg.tor_en = true;
+    cfg.rrid_num = 64;
+    cfg.entry_num = 512;
+    cfg.prio_entry = 16;
+    cfg.prio_ent_prog = false;
+    cfg.non_prio_en = true;
+    cfg.msi_en = true;
+    cfg.peis = true;
+    cfg.pees = true;
+    cfg.sps_en= true;
+    cfg.stall_en = true;
+    cfg.mfr_en = true;
+    cfg.mdcfg_fmt = 0;
+    cfg.srcmd_fmt = 0;
+    cfg.md_entry_num = 0;
+    cfg.xinr = false;
+    cfg.no_x = false;
+    cfg.no_w = false;
+    cfg.rrid_transl_en = true;
+    cfg.rrid_transl_prog = false;
+    cfg.rrid_transl = 48;
+    cfg.entryoffset = 0x2000;
+    cfg.granularity = MIN_GRANULARITY;
+    cfg.imp_mdlck = true;
+    cfg.imp_err_reqid_eid = true;
+    cfg.imp_rridscp = true;
+    cfg.imp_stall_buffer = true;
+    cfg.stall_buffer_size = 32;
+
+    /* Start unit tests */
+
+#if (SRC_ENFORCEMENT_EN == 0)
+    bool val_bool;
+    IOPMP_ERR_REPORT_t err_report = {0};
+
+    START_TEST("Test OFF - Read Access permissions");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4,
+                             IOPMP_ENTRY_FORCE_OFF | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single OFF entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_OFF | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 364, 0, 0, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Write Access permissions");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4,
+                             IOPMP_ENTRY_FORCE_OFF | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single OFF entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_OFF | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 364, 0, 0, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Instruction Fetch permissions");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4,
+                             IOPMP_ENTRY_FORCE_OFF | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single OFF entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_OFF | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 364, 0, 0, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - UNKNOWN RRID ERROR");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4,
+                             IOPMP_ENTRY_FORCE_OFF | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single OFF entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_OFF | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(70, 364, 0, 0, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, UNKNOWN_RRID);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg0.tor_en,
+                  "Test TOR - Partial hit on a priority rule error",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 2, 0, 368,
+                             IOPMP_ENTRY_FORCE_TOR | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 2);  // Two TOR entries
+    FAIL_IF(entries[0].addr != 0);
+    FAIL_IF(entries[0].cfg != IOPMP_ENTRY_R);
+    FAIL_IF(entries[1].addr != (368 >> 2));
+    FAIL_IF(entries[1].cfg != (IOPMP_ENTRY_A_TOR | IOPMP_ENTRY_R));
+    ret = iopmp_set_entries(&iopmp, entries, 0, 2);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 364, 0, 3, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg0.tor_en, "Test TOR - 4Byte Read Access",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 2, 0, 368,
+                             IOPMP_ENTRY_FORCE_TOR | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 2);  // Two TOR entries
+    FAIL_IF(entries[0].addr != 0);
+    FAIL_IF(entries[0].cfg != IOPMP_ENTRY_R);
+    FAIL_IF(entries[1].addr != (368 >> 2));
+    FAIL_IF(entries[1].cfg != (IOPMP_ENTRY_A_TOR | IOPMP_ENTRY_R));
+    ret = iopmp_set_entries(&iopmp, entries, 0, 2);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 364, 0, 2, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg0.tor_en && iopmp_dev.reg_file.hwcfg2.sps_en,
+                  "Test TOR - 4Byte Read Access with SRCMD_R not set",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 2, 0, 368,
+                             IOPMP_ENTRY_FORCE_TOR | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 2);  // Two TOR entries
+    FAIL_IF(entries[0].addr != 0);
+    FAIL_IF(entries[0].cfg != IOPMP_ENTRY_R);
+    FAIL_IF(entries[1].addr != (368 >> 2));
+    FAIL_IF(entries[1].cfg != (IOPMP_ENTRY_A_TOR | IOPMP_ENTRY_R));
+    ret = iopmp_set_entries(&iopmp, entries, 0, 2);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 364, 0, 2, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg0.tor_en && !iopmp_dev.reg_file.hwcfg2.sps_en,
+                  "Test TOR - 4Byte Read Access, SRCMD_R not set, SPS disabled",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 2, 0, 368,
+                             IOPMP_ENTRY_FORCE_TOR | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 2);  // Two TOR entries
+    FAIL_IF(entries[0].addr != 0);
+    FAIL_IF(entries[0].cfg != IOPMP_ENTRY_R);
+    FAIL_IF(entries[1].addr != (368 >> 2));
+    FAIL_IF(entries[1].cfg != (IOPMP_ENTRY_A_TOR | IOPMP_ENTRY_R));
+    ret = iopmp_set_entries(&iopmp, entries, 0, 2);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 364, 0, 2, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg0.tor_en, "Test TOR - 4Byte AMO Write Access",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 2, 0, 368,
+                             IOPMP_ENTRY_FORCE_TOR | IOPMP_ENTRY_W | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 2);  // Two TOR entries
+    FAIL_IF(entries[0].addr != 0);
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_W | IOPMP_ENTRY_R));
+    FAIL_IF(entries[1].addr != (368 >> 2));
+    FAIL_IF(entries[1].cfg != (IOPMP_ENTRY_A_TOR | IOPMP_ENTRY_W | IOPMP_ENTRY_R));
+    ret = iopmp_set_entries(&iopmp, entries, 0, 2);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg0.tor_en,
+                  "Test TOR - 4Byte Non-AMO Write Access",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 2, 0, 368,
+                             IOPMP_ENTRY_FORCE_TOR | IOPMP_ENTRY_W, 0);
+    FAIL_IF(ret != 2);  // Two TOR entries
+    FAIL_IF(entries[0].addr != 0);
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_W));
+    FAIL_IF(entries[1].addr != (368 >> 2));
+    FAIL_IF(entries[1].cfg != (IOPMP_ENTRY_A_TOR | IOPMP_ENTRY_W));
+    ret = iopmp_set_entries(&iopmp, entries, 0, 2);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg0.tor_en, "Test TOR - 4Byte Write Access",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 2, 0, 368,
+                             IOPMP_ENTRY_FORCE_TOR | IOPMP_ENTRY_W, 0);
+    FAIL_IF(ret != 2);  // Two TOR entries
+    FAIL_IF(entries[0].addr != 0);
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_W));
+    FAIL_IF(entries[1].addr != (368 >> 2));
+    FAIL_IF(entries[1].cfg != (IOPMP_ENTRY_A_TOR | IOPMP_ENTRY_W));
+    ret = iopmp_set_entries(&iopmp, entries, 0, 2);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST("Test NA4 - 4Byte Read Access");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 2, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Read Access error");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4, 0, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != IOPMP_ENTRY_A_NA4);
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 2, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.sps_en,
+                  "Test NA4 - 4Byte No SPS Read Access error",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x0, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x0);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 2, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST("Test NA4 - 4Byte Write Access");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4, IOPMP_ENTRY_W | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_W | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Non-AMO Write Access");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4, IOPMP_ENTRY_W, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_W));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Write Access error");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.sps_en,
+                  "Test NA4 - 4Byte No SPS Write Access error",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 32, 0x0, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x0);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4, IOPMP_ENTRY_W | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_W | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST("Test NA4 - 4Byte Execute Access");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4,
+                             IOPMP_ENTRY_X | IOPMP_ENTRY_W | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_X | IOPMP_ENTRY_W | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Execute Access");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4,
+                             IOPMP_ENTRY_W | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_W | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.sps_en,
+                  "Test NA4 - 4Byte No SPS.X, Execute Access",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 32, 0x0, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x0);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4,
+                             IOPMP_ENTRY_X | IOPMP_ENTRY_W | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_X | IOPMP_ENTRY_W | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST("Test NA4 - 8Byte Access error");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 364, 0, 3, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - For exact 4 Byte error");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 364, 4, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NA4 entry
+    FAIL_IF(entries[0].addr != (364 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NA4 | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 368, 0, 0, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access error");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, 0, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != IOPMP_ENTRY_A_NAPOT);
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, READ_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access error");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, 0, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != IOPMP_ENTRY_A_NAPOT);
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8,
+                             IOPMP_ENTRY_W | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_W | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Non-AMO write access");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_W, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_W));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access error");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, 0, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != IOPMP_ENTRY_A_NAPOT);
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.non_prio_en,
+                  "Test NAPOT - 8 Byte Instruction access for non-priority Entry",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 31, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 31, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 17;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 17);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 296, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (296 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x10, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x10);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 32, 0x10, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x10);
+    val_u32 = 25;
+    ret = iopmp_set_md_entry_association(&iopmp, 4, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 25);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, 0, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != IOPMP_ENTRY_A_NAPOT);
+    ret = iopmp_set_entry(&iopmp, entries, 18);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 20);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access when xinr=1");
+    cfg.xinr = true;
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, 0, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != IOPMP_ENTRY_A_NAPOT);
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    iopmp_trans_req.perm = READ_ACCESS; // Since xinr=1, we expect ttype="Read access" in CHECK_IOPMP_TRANS()
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    cfg.xinr = false;
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.imp_mdlck, "Test MDLCK, updating locked srcmd_en field",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u64 = 0x8;
+    ret = iopmp_lock_md(&iopmp, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.imp_mdlck, "Test MDLCK, updating unlocked srcmd_en field",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u64 = 0x4;
+    ret = iopmp_lock_md(&iopmp, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x4);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST("Test MDCFG_LCK, updating locked MDCFG field");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u32 = 4;
+    ret = iopmp_lock_mdcfg(&iopmp, &val_u32, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 4);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test MDCFG_LCK, updating unlocked MDCFG field");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u32 = 2;
+    ret = iopmp_lock_mdcfg(&iopmp, &val_u32, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating locked ENTRY field");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u32 = 4;
+    ret = iopmp_lock_entries(&iopmp, &val_u32, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 4);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u32 = 4;
+    ret = iopmp_lock_entries(&iopmp, &val_u32, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 4);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 5;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 5);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 4);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test SRCMD_EN lock bit, updating locked SRCMD Table");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0, 0, &val_u64, true);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test SRCMD_EN lock bit, updating unlocked SRCMD Table");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 1, 0, 0, &val_u64, true);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 5;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 5);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 4);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.imp_mdlck, "Test MDLCK register lock bit",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u64 = 0x4;
+    ret = iopmp_lock_md(&iopmp, &val_u64, false);   // MD[2] is locked
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x4);
+    ret = iopmp_lock_md(&iopmp, &val_u64, true);    // Locking MDLCK register
+    FAIL_IF(ret != IOPMP_OK);
+    val_u64 = 0x8;
+    ret = iopmp_lock_md(&iopmp, &val_u64, false);   // Trying to lock MD[3] but it shouldn't be locked
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST("Test MDCFG_LCK register lock bit");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u32 = 4;
+    ret = iopmp_lock_mdcfg(&iopmp, &val_u32, false);    // MD[0]-MD[3] are locked
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 4);
+    ret = iopmp_lock_mdcfg(&iopmp, &val_u32, true);     // MDCFGLCK is locked
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 4);
+    val_u32 = 8;
+    ret = iopmp_lock_mdcfg(&iopmp, &val_u32, false);    // Updating locked MD's MD[0]-MD[1] are locked
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK register lock bit");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u32 = 4;
+    ret = iopmp_lock_entries(&iopmp, &val_u32, false);  // ENTRY[0]-ENTRY[3] are locked
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 4);
+    ret = iopmp_lock_entries(&iopmp, &val_u32, true);   // ENTRYLCK is locked
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 4);
+    val_u32 = 8;
+    ret = iopmp_lock_entries(&iopmp, &val_u32, false);  // Updating locked entries but ENTRYLCK was locked
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.mfr_en, "Test MFR Extension",
+    // Following the previous test
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    uint16_t svi = 0;
+    uint16_t svw = 0;
+    ret = iopmp_mfr_get_sv_window(&iopmp, &svi, &svw);
+    FAIL_IF(ret != IOPMP_ERR_NOT_EXIST);
+    FAIL_IF(svi != 0);
+    FAIL_IF(svw != 0);
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    ret = iopmp_mfr_get_sv_window(&iopmp, &svi, &svw);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(svi != 0);
+    FAIL_IF(svw != 4);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.imp_mdlck, "Test MDLCK, updating locked srcmd_enh field",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u64 = 0x80000000;
+    ret = iopmp_lock_md(&iopmp, &val_u64, false);   // MD[31] is locked
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_ERR_REG_IS_LOCKED);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.imp_mdlck, "Test MDLCK, updating unlocked srcmd_enh field",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u64 = 0x100000000;
+    ret = iopmp_lock_md(&iopmp, &val_u64, false);   // MD[32] is locked
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x100000000);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.peis, "Test Interrupt Suppression is Enabled",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_global_intr(&iopmp, true);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8,
+                             IOPMP_ENTRY_SIXE | IOPMP_ENTRY_R, 0);  // Address Mode is NAPOT, with read permission and ixe suppression
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_SIXE | IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST("Test Interrupt Suppression is disabled");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_global_intr(&iopmp, true);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.pees, "Test Error Suppression is Enabled",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_bool = true;
+    ret = iopmp_set_global_err_resp(&iopmp, &val_bool);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_bool != true);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8,
+                             IOPMP_ENTRY_SEXE | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_SEXE | IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_R));    // Address Mode is NAPOT, with read permission and exe suppression
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(&iopmp_dev, NO_ERROR, INSTR_FETCH, 360, 0);
+    ret = iopmp_capture_error(&iopmp, &err_report, false);
+    FAIL_IF(ret != IOPMP_ERR_NOT_EXIST);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.pees,
+                  "Test Error Suppression is Enabled but rs is zero",
+    // Receiver Port Signals
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8,
+                             IOPMP_ENTRY_SEXE | IOPMP_ENTRY_R, 0);  // Address Mode is NAPOT, with read permission and exe suppression
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_SEXE | IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(&iopmp_dev, NO_ERROR, INSTR_FETCH, 360, 0);
+    ret = iopmp_capture_error(&iopmp, &err_report, false);
+    FAIL_IF(ret != IOPMP_ERR_NOT_EXIST);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST("Test Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != 0));
+    error_record_chk(&iopmp_dev, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    ret = iopmp_capture_error(&iopmp, &err_report, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF((err_report.etype != IOPMP_ERRINFO_ETYPE_INST_FETCH));
+    FAIL_IF((err_report.ttype != IOPMP_ERRINFO_TTYPE_INST_FETCH));
+    FAIL_IF((err_report.addr != (360 >> 2)));
+    FAIL_IF((err_report.rrid != 2));
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.peis && iopmp_dev.reg_file.hwcfg2.pees,
+                  "Test Interrupt and Error Suppression is Enabled",
+    // Receiver Port Signals
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_global_intr(&iopmp, true);
+    FAIL_IF(ret != IOPMP_OK);
+    val_bool = true;
+    ret = iopmp_set_global_err_resp(&iopmp, &val_bool);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_bool != true);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8,
+                             IOPMP_ENTRY_SEXE | IOPMP_ENTRY_SIXE | IOPMP_ENTRY_R, 0);  // Address Mode is NAPOT, with read permission and ixe/exe suppression
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_SEXE | IOPMP_ENTRY_SIXE | IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((intrpt == 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(&iopmp_dev, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 0);
+    ret = iopmp_capture_error(&iopmp, &err_report, false);
+    FAIL_IF(ret != IOPMP_ERR_NOT_EXIST);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST("Test Interrupt and Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_global_intr(&iopmp, true);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((intrpt != 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    error_record_chk(&iopmp_dev, ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360, 1);
+    ret = iopmp_capture_error(&iopmp, &err_report, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF((err_report.etype != IOPMP_ERRINFO_ETYPE_INST_FETCH));
+    FAIL_IF((err_report.ttype != IOPMP_ERRINFO_TTYPE_INST_FETCH));
+    FAIL_IF((err_report.addr != (360 >> 2)));
+    FAIL_IF((err_report.rrid != 2));
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.stall_en && iopmp_dev.imp_rridscp, "Stall MD Feature",
+    cfg.imp_stall_buffer = true;
+    cfg.stall_buffer_size = 32;
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 5, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 5, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u64 = 0x8;
+    ret = iopmp_stall_transactions_by_mds(&iopmp, &val_u64, false, true);
+    FAIL_IF(ret != IOPMP_OK);
+    enum iopmp_rridscp_stat stat = {0};
+    val_u32 = 5;
+    ret = iopmp_stall_cherry_pick_rrid(&iopmp, &val_u32, true, &stat);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(stat != IOPMP_RRIDSCP_STAT_STALLED);
+
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
+    val_u32 = 5;
+    ret = iopmp_query_stall_stat_by_rrid(&iopmp, &val_u32, &stat);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(stat != IOPMP_RRIDSCP_STAT_STALLED);
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.stall_en && iopmp_dev.imp_rridscp,
+                  "Faulting Stalled Transactions Feature",
+    cfg.imp_stall_buffer = false;
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    val_bool = true;
+    ret = iopmp_set_stall_violation_en(&iopmp, &val_bool);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_bool != true);
+    ret = iopmp_set_rrid_md_association(&iopmp, 5, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 5, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_X, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_X));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+    val_u64 = 0x8;
+    ret = iopmp_stall_transactions_by_mds(&iopmp, &val_u64, false, true);
+    FAIL_IF(ret != IOPMP_OK);
+    enum iopmp_rridscp_stat stat = {0};
+    val_u32 = 5;
+    ret = iopmp_stall_cherry_pick_rrid(&iopmp, &val_u32, true, &stat);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(stat != IOPMP_RRIDSCP_STAT_STALLED);
+
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
+    val_u32 = 5;
+    ret = iopmp_query_stall_stat_by_rrid(&iopmp, &val_u32, &stat);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(stat != IOPMP_RRIDSCP_STAT_STALLED);
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, STALLED_TRANSACTION);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    // Reset configuration
+    cfg.imp_stall_buffer = true;
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg3.rrid_transl_en, "Test Cascading IOPMP Feature",
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 32, 0x8, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 32, 0x8, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x8);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 3, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8,
+                             IOPMP_ENTRY_W | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_W | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_transl != iopmp_dev.reg_file.hwcfg3.rrid_transl));
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.msi_en, "Test MSI Write error",
+    uint64_t read_data;
+    uint64_t msiaddr64;
+    uint16_t msidata;
+    reset_iopmp(&iopmp_dev, &cfg);
+    bus_error = 0x8000;
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_global_intr(&iopmp, true);
+    FAIL_IF(ret != IOPMP_OK);
+    val_bool = true;
+    ret = iopmp_set_msi_sel(&iopmp, &val_bool);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_bool != true);
+    msiaddr64 = 0x8000;
+    msidata = 0x8F;
+    ret = iopmp_set_msi_info(&iopmp, &msiaddr64, &msidata);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(msiaddr64 != 0x8000);
+    FAIL_IF(msidata != 0x8F);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    bus_error = 0;
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data == 0x8F); // Interrupt is not suppressed
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+
+    START_TEST_IF(iopmp_dev.reg_file.hwcfg2.msi_en, "Test MSI",
+    uint64_t read_data;
+    uint64_t msiaddr64;
+    uint16_t msidata;
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_global_intr(&iopmp, true);
+    FAIL_IF(ret != IOPMP_OK);
+    val_bool = true;
+    ret = iopmp_set_msi_sel(&iopmp, &val_bool);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_bool != true);
+    msiaddr64 = 0x8000;
+    msidata = 0x8F;
+    ret = iopmp_set_msi_info(&iopmp, &msiaddr64, &msidata);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(msiaddr64 != 0x8000);
+    FAIL_IF(msidata != 0x8F);
+    ret = iopmp_set_rrid_md_association(&iopmp, 2, 0x80000000, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    ret = iopmp_sps_set_rrid_md_insn_fetch(&iopmp, 2, 0x80000000, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x80000000);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 31, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8, IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 1);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();)
+#endif
+
+    free(memory);
+
+#if (SRC_ENFORCEMENT_EN)
+    START_TEST("Test SourceEnforcement Enable Feature");
+    reset_iopmp(&iopmp_dev, &cfg);
+
+    ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_0, IOPMP_MDCFG_FMT_0,
+                     IOPMP_IMPID_NOT_SPECIFIED);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_rrid_md_association(&iopmp, 0, 0x1, 0, &val_u64, false);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x1);
+    ret = iopmp_sps_set_rrid_md_read(&iopmp, 0, 0x1, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x1);
+    ret = iopmp_sps_set_rrid_md_write(&iopmp, 0, 0x1, 0, &val_u64);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u64 != 0x1);
+    val_u32 = 2;
+    ret = iopmp_set_md_entry_association(&iopmp, 0, &val_u32);
+    FAIL_IF(ret != IOPMP_OK);
+    FAIL_IF(val_u32 != 2);
+    ret = iopmp_encode_entry(&iopmp, entries, 1, 360, 8,
+                             IOPMP_ENTRY_W | IOPMP_ENTRY_R, 0);
+    FAIL_IF(ret != 1);  // Single NAPOT entry
+    FAIL_IF(entries[0].addr != (360 >> 2));
+    FAIL_IF(entries[0].cfg != (IOPMP_ENTRY_A_NAPOT | IOPMP_ENTRY_W | IOPMP_ENTRY_R));
+    ret = iopmp_set_entry(&iopmp, entries, 0);
+    FAIL_IF(ret != IOPMP_OK);
+    ret = iopmp_set_enable(&iopmp);
+    FAIL_IF(ret != IOPMP_OK);
+
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    receiver_port(12, 360, 0, 3, WRITE_ACCESS, 1, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(&iopmp_dev, IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(&iopmp_dev, ERR_INFO_OFFSET, 0, 4);
+    END_TEST();
+#endif
+
+    return 0;
+}

--- a/iopmp_ref_model/verif/tests/rapidmodel.c
+++ b/iopmp_ref_model/verif/tests/rapidmodel.c
@@ -513,12 +513,10 @@ int main()
     configure_srcmd_n(&iopmp, SRCMD_X, 31, 0x10, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 3), 74, 4); // (300 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 3), 0x1C, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_srcmd_n(&iopmp, SRCMD_EN, 32, 0x20, 4);
     configure_srcmd_n(&iopmp, SRCMD_X, 32, 0x20, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 4), 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 4), 0x18, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 4), 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 4), 0x1C, 4);
     set_hwcfg0_enable(&iopmp);

--- a/iopmp_ref_model/verif/tests/unnamed_model_1.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_1.c
@@ -392,10 +392,8 @@ int main()
     receiver_port(32, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     configure_entry_n(&iopmp, ENTRY_ADDR, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 74, 4);
     configure_entry_n(&iopmp, ENTRY_CFG, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 0x1C, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 90, 4);
     configure_entry_n(&iopmp, ENTRY_CFG, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 0x18, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 90, 4);
     configure_entry_n(&iopmp, ENTRY_CFG, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), 0x1C, 4);
     set_hwcfg0_enable(&iopmp);

--- a/iopmp_ref_model/verif/tests/unnamed_model_2.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_2.c
@@ -403,12 +403,10 @@ int main()
     configure_mdcfg_n(&iopmp, 29, 17, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 1, 74, 4); // (300 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_srcmd_n(&iopmp, SRCMD_PERMH, 30, 0x18, 4);
     configure_mdcfg_n(&iopmp, 30, 25, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 18, 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 18, 0x18, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, 20, 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 20, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);

--- a/iopmp_ref_model/verif/tests/unnamed_model_3.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_3.c
@@ -378,11 +378,9 @@ int main()
     configure_srcmd_n(&iopmp, SRCMD_PERMH, 29, 0x1C, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 1, 74, 4); // (300 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_srcmd_n(&iopmp, SRCMD_PERMH, 30, 0x18, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 18, 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 18, 0x18, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, 20, 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 20, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);

--- a/iopmp_ref_model/verif/tests/unnamed_model_4.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_4.c
@@ -360,11 +360,9 @@ int main()
     configure_srcmd_n(&iopmp, SRCMD_PERMH, 29, 0x1C, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 1, 74, 4); // (300 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_srcmd_n(&iopmp, SRCMD_PERMH, 30, 0x18, 4);
     configure_entry_n(&iopmp, ENTRY_ADDR, 18, 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 18, 0x18, 4);
-    set_hwcfg0_enable(&iopmp);
     configure_entry_n(&iopmp, ENTRY_ADDR, 20, 90, 4); // (364 >> 2) and keeping lsb 0
     configure_entry_n(&iopmp, ENTRY_CFG, 20, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);

--- a/libiopmp/include/libiopmp.h
+++ b/libiopmp/include/libiopmp.h
@@ -518,14 +518,14 @@ enum iopmp_entry_flags {
 
     /** [Software flag] Forcefully set ENTRY_CFG.a = OFF */
     IOPMP_ENTRY_FORCE_OFF = (1UL << 27),
-    /** [Software flag] Forcefully set ENTRY(0).a = TOR */
+    /** [Software flag] Forcefully set ENTRY_CFG(0).a = TOR */
     IOPMP_ENTRY_FIRST_TOR = (1UL << 28),
-    /** [Software flag] Forcefully set ENTRY.a = TOR */
+    /** [Software flag] Forcefully set ENTRY_CFG.a = TOR */
     IOPMP_ENTRY_FORCE_TOR = (1UL << 29),
 
-    /** [Software flag] FLag to indicate this entry is priority entry */
+    /** [Software flag] Flag to indicate this entry is priority entry */
     IOPMP_ENTRY_PRIO = (1UL << 30),
-    /** [Software flag] FLag to indicate this entry is non-priority entry */
+    /** [Software flag] Flag to indicate this entry is non-priority entry */
     IOPMP_ENTRY_NON_PRIO = (1UL << 31),
 
     /** Bit mask of all software flags */
@@ -2015,10 +2015,10 @@ enum iopmp_error iopmp_sps_get_rrid_md_write(IOPMP_t *iopmp, uint32_t rrid,
  * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
  *         actual values
  */
-enum iopmp_error iopmp_sps_set_rrid_insn_fetch(IOPMP_t *iopmp, uint32_t rrid,
-                                               uint64_t mds_set,
-                                               uint64_t mds_clr,
-                                               uint64_t *mds);
+enum iopmp_error iopmp_sps_set_rrid_md_insn_fetch(IOPMP_t *iopmp, uint32_t rrid,
+                                                  uint64_t mds_set,
+                                                  uint64_t mds_clr,
+                                                  uint64_t *mds);
 
 /**
  * \brief (SPS only) Get RRID's instruction fetch permission to MDs

--- a/libiopmp/src/iopmp_drv_common.c
+++ b/libiopmp/src/iopmp_drv_common.c
@@ -452,17 +452,34 @@ static void detect_stall_function(IOPMP_t *iopmp)
 
 void detect_entry_addr_bits(IOPMP_t *iopmp)
 {
-    uint64_t val;
-    uintptr_t addr_entry_0 = iopmp->addr_entry_array;
+    uint64_t val = 0;
+    uintptr_t entry;
+    uint32_t entrylck_f, entry_cfg, entry_addr, entry_addrh;
+    int i;
 
-    io_write32(addr_entry_0 + IOPMP_ENTRY_CFG_BASE, 0);
-    io_write32(addr_entry_0 + IOPMP_ENTRY_ADDR_BASE, 0xFFFFFFFF);
-    val = io_read32(addr_entry_0 + IOPMP_ENTRY_ADDR_BASE);
-    io_write32(addr_entry_0 + IOPMP_ENTRY_ADDR_BASE, 0);    /* Clear */
-    if (iopmp->addrh_en) {
-        io_write32(addr_entry_0 + IOPMP_ENTRY_ADDRH_BASE, 0xFFFFFFFF);
-        val |= (uint64_t)io_read32(addr_entry_0 + IOPMP_ENTRY_ADDRH_BASE) << 32;
-        io_write32(addr_entry_0 + IOPMP_ENTRY_ADDRH_BASE, 0);   /* Clear */
+    entrylck_f = EXTRACT_FIELD(io_read32(iopmp->addr + IOPMP_ENTRYLCK_BASE),
+                               IOPMP_ENTRYLCK_F);
+    /*Search for an unlocked and unused entry that we can safely use to detect*/
+    for (i = entrylck_f; i < iopmp->entry_num; i++) {
+        entry = get_addr_of_entry(iopmp, i);
+        entry_cfg = io_read32(entry + IOPMP_ENTRY_CFG_BASE);
+        entry_addr = io_read32(entry + IOPMP_ENTRY_ADDR_BASE);
+        entry_addrh = iopmp->addrh_en ?
+                      io_read32(entry + IOPMP_ENTRY_ADDRH_BASE) : 0;
+        if (entry_cfg || entry_addr || entry_addrh) {
+            /* Search for next entry */
+            continue;
+        }
+
+        io_write32(entry + IOPMP_ENTRY_ADDR_BASE, 0xFFFFFFFF);
+        val = io_read32(entry + IOPMP_ENTRY_ADDR_BASE);
+        io_write32(entry + IOPMP_ENTRY_ADDR_BASE, 0);       /* Clear */
+        if (iopmp->addrh_en) {
+            io_write32(entry + IOPMP_ENTRY_ADDRH_BASE, 0xFFFFFFFF);
+            val |= (uint64_t)io_read32(entry + IOPMP_ENTRY_ADDRH_BASE) << 32;
+            io_write32(entry + IOPMP_ENTRY_ADDRH_BASE, 0);  /* Clear */
+        }
+        break;
     }
 
     iopmp->entry_addr_bits = val;

--- a/libiopmp/src/iopmp_drv_common.c
+++ b/libiopmp/src/iopmp_drv_common.c
@@ -394,15 +394,6 @@ DECLARE_FUNC_GET_ADDR_OF_ENTRY(entry_cfg,   IOPMP_ENTRY_CFG_BASE);
 /******************************************************************************/
 /* Internal functions to read/write value from/to IOPMP instance              */
 /******************************************************************************/
-static void write_hwcfg0(IOPMP_t *iopmp, uint32_t mask, uint32_t val)
-{
-    uint32_t hwcfg0;
-
-    hwcfg0 = io_read32(iopmp->addr + IOPMP_HWCFG0_BASE);
-    hwcfg0 = (hwcfg0 & ~mask) | (val & mask);
-    io_write32(iopmp->addr + IOPMP_HWCFG0_BASE, hwcfg0);
-}
-
 static void write_hwcfg2(IOPMP_t *iopmp, uint32_t mask, uint32_t val)
 {
     uint32_t hwcfg2;
@@ -496,7 +487,7 @@ void detect_entry_addr_bits(IOPMP_t *iopmp)
  */
 static void generic_enable(IOPMP_t *iopmp)
 {
-    write_hwcfg0(iopmp, IOPMP_HWCFG0_ENABLE_MASK, IOPMP_HWCFG0_ENABLE_MASK);
+    io_write32(iopmp->addr + IOPMP_HWCFG0_BASE, IOPMP_HWCFG0_ENABLE_MASK);
 }
 
 /**


### PR DESCRIPTION
- Add libiopmp full model test cases which referring to existing `fullmodel.c`
- Improve detection of implemented `ENTRY_ADDR(H)` bits
- Fix typo