### PR TITLE
libiopmp: Reduce default operation tables

### DIFF
--- a/iopmp_ref_model/Makefile
+++ b/iopmp_ref_model/Makefile
@@ -28,7 +28,7 @@ LIBIOPMP_PREREQ =
 ifeq ($(libiopmp), 1)
 # Enable coverage analysis
 cov = 1
-LIBIOPMP_CFLAGS += -I$(LIBIOPMP_DIR)/include
+LIBIOPMP_CFLAGS += -I$(LIBIOPMP_DIR)/include -I$(LIBIOPMP_DIR)/src
 LIBIOPMP_LDFLAGS += $(LIBIOPMP) -lgcov
 # Prerequisite
 LIBIOPMP_PREREQ += $(LIBIOPMP)

--- a/iopmp_ref_model/verif/tests/libiopmp_fullmodel.c
+++ b/iopmp_ref_model/verif/tests/libiopmp_fullmodel.c
@@ -3,6 +3,7 @@
 #include "test_utils.h"
 
 #include "libiopmp.h"
+#include "libiopmp_def.h"
 
 // Declarations
 iopmp_trans_req_t iopmp_trans_req;
@@ -37,6 +38,23 @@ static enum iopmp_error libiopmp_setup(IOPMP_t *iopmp, iopmp_cfg_t *cfg)
     return iopmp_init(iopmp, 0, cfg->srcmd_fmt, cfg->mdcfg_fmt,
                       IOPMP_IMPID_NOT_SPECIFIED);
 }
+
+#if (SRC_ENFORCEMENT_EN == 0)
+/* A per-instance generic override, for the two-instance dispatch test. Only
+ * set_global_intr is filled in, so every other operation has to fall back. */
+static int fake_set_global_intr_hits;
+
+static void fake_set_global_intr(IOPMP_t *iopmp, bool enable)
+{
+    (void)iopmp;
+    (void)enable;
+    fake_set_global_intr_hits++;
+}
+
+static struct iopmp_operations_generic fake_ops_generic = {
+    .set_global_intr = fake_set_global_intr,
+};
+#endif
 
 #define CFG_MD_NUM          63
 #define CFG_ENTRY_NUM       512
@@ -3293,6 +3311,32 @@ int main(void)
     ret = iopmp_init(&iopmp, 0, IOPMP_SRCMD_FMT_1, IOPMP_MDCFG_FMT_0,
                      IOPMP_IMPID_NOT_SPECIFIED);
     FAIL_IF(ret != IOPMP_ERR_NOT_SUPPORTED);
+    END_TEST();
+
+    START_TEST("A generic override applies to one instance, not the others");
+    {
+        IOPMP_t iopmp_ovr;
+
+        /* Two instances in one image: one with an override, one without */
+        FAIL_IF(libiopmp_setup(&iopmp_ovr, &cfg) != IOPMP_OK);
+        iopmp_ovr.ops_generic = &fake_ops_generic;
+        FAIL_IF(libiopmp_setup(&iopmp, &cfg) != IOPMP_OK);
+
+        /* Member filled in: the override runs and ERR_CFG.ie stays clear */
+        fake_set_global_intr_hits = 0;
+        FAIL_IF(iopmp_set_global_intr(&iopmp_ovr, true) != IOPMP_OK);
+        FAIL_IF(fake_set_global_intr_hits != 1);
+        FAIL_IF(read_register(&iopmp_dev, ERR_CFG_OFFSET, 4) & 0x2);
+
+        /* ops_generic is NULL here, so the built-in runs and sets ERR_CFG.ie */
+        FAIL_IF(iopmp_set_global_intr(&iopmp, true) != IOPMP_OK);
+        FAIL_IF(fake_set_global_intr_hits != 1);
+        FAIL_IF(!(read_register(&iopmp_dev, ERR_CFG_OFFSET, 4) & 0x2));
+
+        /* Member left NULL: the override instance falls back to the built-in */
+        FAIL_IF(iopmp_lock_err_cfg(&iopmp_ovr) != IOPMP_OK);
+        FAIL_IF(!(read_register(&iopmp_dev, ERR_CFG_OFFSET, 4) & 0x1));
+    }
     END_TEST();
 #endif
 

--- a/iopmp_ref_model/verif/tests/libiopmp_fullmodel.c
+++ b/iopmp_ref_model/verif/tests/libiopmp_fullmodel.c
@@ -51,8 +51,17 @@ static void fake_set_global_intr(IOPMP_t *iopmp, bool enable)
     fake_set_global_intr_hits++;
 }
 
+static int fake_invalidate_error_hits;
+
+static void fake_invalidate_error(IOPMP_t *iopmp)
+{
+    (void)iopmp;
+    fake_invalidate_error_hits++;
+}
+
 static struct iopmp_operations_generic fake_ops_generic = {
     .set_global_intr = fake_set_global_intr,
+    .invalidate_error = fake_invalidate_error,
 };
 #endif
 
@@ -3336,6 +3345,32 @@ int main(void)
         /* Member left NULL: the override instance falls back to the built-in */
         FAIL_IF(iopmp_lock_err_cfg(&iopmp_ovr) != IOPMP_OK);
         FAIL_IF(!(read_register(&iopmp_dev, ERR_CFG_OFFSET, 4) & 0x1));
+    }
+    END_TEST();
+
+    START_TEST("capture_error dispatches an invalidate_error override");
+    {
+        IOPMP_t iopmp_ovr;
+
+        FAIL_IF(libiopmp_setup(&iopmp_ovr, &cfg) != IOPMP_OK);
+        iopmp_ovr.ops_generic = &fake_ops_generic;
+        /* RRID 2 is associated with a MD that owns no entry, so the access
+         * below hits no rule and leaves a record behind */
+        FAIL_IF(iopmp_set_rrid_md_association(&iopmp_ovr, 2, 0x8, 0, &val_u64,
+                                              false) != IOPMP_OK);
+        FAIL_IF(iopmp_set_enable(&iopmp_ovr) != IOPMP_OK);
+        receiver_port(2, 364, 0, 0, READ_ACCESS, 0, &iopmp_trans_req);
+        iopmp_validate_access(&iopmp_dev, &iopmp_trans_req, &iopmp_trans_rsp,
+                              &intrpt);
+        FAIL_IF(iopmp_trans_rsp.status != IOPMP_ERROR);
+
+        /* capture_error is the built-in here, but invalidate_error is not:
+         * the built-in has to reach the override rather than clear the record
+         * itself, so ERR_INFO.v survives */
+        fake_invalidate_error_hits = 0;
+        FAIL_IF(iopmp_capture_error(&iopmp_ovr, &err_report, true) != IOPMP_OK);
+        FAIL_IF(fake_invalidate_error_hits != 1);
+        FAIL_IF(!(read_register(&iopmp_dev, ERR_INFO_OFFSET, 4) & 0x1));
     }
     END_TEST();
 #endif

--- a/libiopmp/Makefile
+++ b/libiopmp/Makefile
@@ -51,10 +51,6 @@ CFLAGS	+= --coverage
 CFLAGS	+= -DENABLE_IO_WEAK_FUNCTIONS
 endif
 
-ifeq ($(CFG_IOPMP_DRV_SPS_EXTENSION),y)
-CFLAGS	+= -DENABLE_SPS
-endif
-
 ARFLAGS	= rcs
 
 # Check if verbosity is ON for build process

--- a/libiopmp/README.md
+++ b/libiopmp/README.md
@@ -39,8 +39,6 @@ compiling of driver for SRCMD_FMT=2 & MDCFG_FMT=0
 compiling of driver for SRCMD_FMT=2 & MDCFG_FMT=1
 * `CFG_IOPMP_DRV_SRCMD_FMT_2_MDCFG_FMT_2`: Turn on this option to enable
 compiling of driver for SRCMD_FMT=2 & MDCFG_FMT=2
-* `CFG_IOPMP_DRV_SPS_EXTENSION`: Turn on this option to enable compiling of
-driver for Secondary Permission Setting (SPS) extension
 
 ## Compilation
 

--- a/libiopmp/config.mk
+++ b/libiopmp/config.mk
@@ -30,6 +30,3 @@ CFG_IOPMP_DRV_SRCMD_FMT_2_MDCFG_FMT_1=y
 
 # Set to 'y' to enable compiling of driver for SRCMD_FMT=2 & MDCFG_FMT=2
 CFG_IOPMP_DRV_SRCMD_FMT_2_MDCFG_FMT_2=y
-
-# Set to 'y' to enable compiling of driver for SPS(Secondary Permission Setting)
-CFG_IOPMP_DRV_SPS_EXTENSION=y

--- a/libiopmp/include/libiopmp.h
+++ b/libiopmp/include/libiopmp.h
@@ -39,8 +39,6 @@ struct iopmp_instance {
     struct iopmp_operations_generic *ops_generic;
     /** Operations for specific model */
     struct iopmp_operations_specific *ops_specific;
-    /** Operations for model supports SPS extension */
-    struct iopmp_operations_sps *ops_sps;
 
     /** Base MMIO physical address of IOPMP entries */
     uintptr_t addr_entry_array;
@@ -731,12 +729,12 @@ static inline bool iopmp_get_support_tor(IOPMP_t *iopmp)
  *
  * \param[in] iopmp             The IOPMP instance to be checked
  *
- * \retval 1 if HWCFG2.sps_en = 1 and the SPS operations are implemented
+ * \retval 1 if HWCFG2.sps_en = 1
  * \retval 0 if HWCFG2.sps_en = 0
  */
 static inline bool iopmp_get_support_sps(IOPMP_t *iopmp)
 {
-    return iopmp->sps_en && iopmp->ops_sps;
+    return iopmp->sps_en;
 }
 
 /**

--- a/libiopmp/include/libiopmp.h
+++ b/libiopmp/include/libiopmp.h
@@ -35,7 +35,7 @@ struct iopmp_instance {
     uint32_t granularity;
     /** Implemented bits of ENTRY_ADDR(H) */
     uint64_t entry_addr_bits;
-    /** Generic operations for all models */
+    /** Per-instance override of the generic operations, NULL for none */
     struct iopmp_operations_generic *ops_generic;
     /** Operations for specific model */
     struct iopmp_operations_specific *ops_specific;
@@ -1627,10 +1627,13 @@ enum iopmp_error iopmp_set_global_intr(IOPMP_t *iopmp, bool enable);
  * \retval IOPMP_OK if successes
  * \retval IOPMP_ERR_INVALID_PARAMETER if given \p suppress is NULL
  * \retval IOPMP_ERR_REG_IS_LOCKED if ERR_CFG register is locked
- * \retval IOPMP_ERR_NOT_SUPPORTED if \p iopmp does not support configure global
- *         error responses
  * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p suppress does not match
  *         the actual value. The actual value is output via \p suppress
+ *
+ * \note ERR_CFG.rs is WARL and has no capability bit in HWCFG, so an
+ *       implementation that hardwires it is reported this way rather than as
+ *       IOPMP_ERR_NOT_SUPPORTED: \p suppress comes back holding the value the
+ *       hardware is fixed at
  */
 enum iopmp_error iopmp_set_global_err_resp(IOPMP_t *iopmp, bool *suppress);
 

--- a/libiopmp/src/iopmp_drv_common.c
+++ b/libiopmp/src/iopmp_drv_common.c
@@ -505,51 +505,24 @@ enum iopmp_error detect_entry_addr_bits(IOPMP_t *iopmp)
 /******************************************************************************/
 /* Implementation of libiopmp APIs                                            */
 /******************************************************************************/
-/**
- * \brief Set the IOPMP HWCFG0.enable
- *
- * \param[in] iopmp             The IOPMP instance to be set
- */
-static void generic_enable(IOPMP_t *iopmp)
+void generic_enable(IOPMP_t *iopmp)
 {
     io_write32(iopmp->addr + IOPMP_HWCFG0_BASE, IOPMP_HWCFG0_ENABLE_MASK);
 }
 
-/**
- * \brief Lock number of priority entry
- *
- * \param[in] iopmp             The IOPMP instance
- */
-static void generic_lock_prio_entry_num(IOPMP_t *iopmp)
+void generic_lock_prio_entry_num(IOPMP_t *iopmp)
 {
     write_hwcfg2(iopmp, IOPMP_HWCFG2_PRIO_ENT_PROG_MASK,
                  IOPMP_HWCFG2_PRIO_ENT_PROG_MASK);
 }
 
-/**
- * \brief Lock the RRID tagged to outgoing transactions
- *
- * \param[in] iopmp             The IOPMP instance
- */
-static void generic_lock_rrid_transl(IOPMP_t *iopmp)
+void generic_lock_rrid_transl(IOPMP_t *iopmp)
 {
     write_hwcfg3(iopmp, IOPMP_HWCFG3_RRID_TRANSL_PROG_MASK,
                  IOPMP_HWCFG3_RRID_TRANSL_PROG_MASK);
 }
 
-/**
- * \brief Set IOPMP HWCFG2.prio_entry
- *
- * \param[in] iopmp             The IOPMP instance to be set
- * \param[in,out] num_entry     Input the number of entries to be matched with
- *                              priority. Output WARL value.
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p num_entry does not match
- *         the actual value. The actual value is output via \p num_entry
- */
-static enum iopmp_error generic_set_prio_entry_num(IOPMP_t *iopmp,
-                                                   uint16_t *num_entry)
+enum iopmp_error generic_set_prio_entry_num(IOPMP_t *iopmp, uint16_t *num_entry)
 {
     uint16_t __prio_entry = *num_entry;
     uint32_t hwcfg2;
@@ -564,19 +537,7 @@ static enum iopmp_error generic_set_prio_entry_num(IOPMP_t *iopmp,
     return (__prio_entry == *num_entry) ? IOPMP_OK : IOPMP_ERR_ILLEGAL_VALUE;
 }
 
-/**
- * \brief Set IOPMP HWCFG3.rrid_transl
- *
- * \param[in] iopmp             The IOPMP instance to be set
- * \param[in,out] rrid_transl   Input the value of rrid_transl to be set. Output
- *                              WARL value
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p rrid_transl does not
- *         match the actual value. The actual value is output via \p rrid_transl
- */
-static enum iopmp_error generic_set_rrid_transl(IOPMP_t *iopmp,
-                                                uint16_t *rrid_transl)
+enum iopmp_error generic_set_rrid_transl(IOPMP_t *iopmp, uint16_t *rrid_transl)
 {
     uint16_t __rrid_transl = *rrid_transl;
     uint32_t hwcfg3;
@@ -683,23 +644,8 @@ static void __polling_mdstall(IOPMP_t *iopmp)
     } while(EXTRACT_FIELD(mdstall, IOPMP_MDSTALL_IS_BUSY));
 }
 
-/**
- * \brief Set MDSTALL to stall the transactions related to MDs bitmap, and poll
- * the stall status until stall takes effect if necessary
- *
- * \param[in] iopmp             The IOPMP instance to be set
- * \param[in,out] mds           Input the MD bitmap to be stalled. Output WARL
- *                              value
- * \param[in] exempt            Stall transactions with exempt selected MDs
- * \param[in] polling           Set true to poll the stall status until stalling
- *                              takes effect
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
- *         actual value. The actual value is output via \p mds
- */
-static enum iopmp_error generic_stall_by_mds(IOPMP_t *iopmp, uint64_t *mds,
-                                             bool exempt, bool polling)
+enum iopmp_error generic_stall_by_mds(IOPMP_t *iopmp, uint64_t *mds,
+                                      bool exempt, bool polling)
 {
     enum iopmp_error ret;
 
@@ -713,20 +659,7 @@ static enum iopmp_error generic_stall_by_mds(IOPMP_t *iopmp, uint64_t *mds,
     return IOPMP_OK;
 }
 
-/**
- * \brief Resume the stalled transactions previously stalled, and poll the
- * resume status until resuming takes effect if necessary
- *
- * \param[in] iopmp             The IOPMP instance to be resumed
- * \param[in] polling           Set true to poll the resume status until
- *                              resuming takes effect
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
- *         actual value
- */
-static enum iopmp_error generic_resume_transactions(IOPMP_t *iopmp,
-                                                    bool polling)
+enum iopmp_error generic_resume_transactions(IOPMP_t *iopmp, bool polling)
 {
     enum iopmp_error ret;
 
@@ -740,19 +673,7 @@ static enum iopmp_error generic_resume_transactions(IOPMP_t *iopmp,
     return IOPMP_OK;
 }
 
-/**
- * \brief Poll until MDSTALL.is_busy == 0
- *
- * \param[in] iopmp             The IOPMP instance to be checked
- * \param[in] polling           Set true to poll the status until takes effect
- * \param[in] stall_or_resume   Set true to poll for stall status or set false
- *                              to poll for resume status
- *
- * \retval 1 if the previous operation has taken effect
- * \retval 0 if the previous operation has not taken effect yet
- */
-static bool generic_poll_mdstall(IOPMP_t *iopmp, bool polling,
-                                 bool stall_or_resume)
+bool generic_poll_mdstall(IOPMP_t *iopmp, bool polling, bool stall_or_resume)
 {
     uint32_t mdstall;
 
@@ -769,21 +690,9 @@ static bool generic_poll_mdstall(IOPMP_t *iopmp, bool polling,
     return EXTRACT_FIELD(mdstall, IOPMP_MDSTALL_IS_BUSY) == false;
 }
 
-/**
- * \brief Write RRIDSCP with given RRID and operation
- *
- * \param[in] iopmp             The IOPMP instance to be set
- * \param[in,out] rrid          Input the RRID to be stalled. Output WARL value
- * \param[in] op                The operation of RRIDSCP
- * \param[out] stat             The pointer to store enum iopmp_rridscp_stat
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p rrid does not match the
- *         actual value. The actual value is output via \p rrid
- */
-static enum iopmp_error generic_set_rridscp(IOPMP_t *iopmp, uint32_t *rrid,
-                                            enum iopmp_rridscp_op op,
-                                            enum iopmp_rridscp_stat *stat)
+enum iopmp_error generic_set_rridscp(IOPMP_t *iopmp, uint32_t *rrid,
+                                     enum iopmp_rridscp_op op,
+                                     enum iopmp_rridscp_stat *stat)
 {
     uint32_t rridscp;
     uint32_t __rrid = *rrid;
@@ -801,21 +710,8 @@ static enum iopmp_error generic_set_rridscp(IOPMP_t *iopmp, uint32_t *rrid,
     return (__rrid == *rrid) ? IOPMP_OK : IOPMP_ERR_ILLEGAL_VALUE;
 }
 
-/**
- * \brief Lock ENTRY(0) ~ ENTRY(entry_num - 1)
- *
- * \param[in] iopmp             The IOPMP instance to be set
- * \param[in,out] entry_num     Input the number of entry to be locked. Output
- *                              WARL value
- * \param[in] lock              Lock ENTRYLCK register or not
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p entry_num does not match
- *         the actual value. The actual value is output via \p entry_num
- */
-static enum iopmp_error generic_lock_entries(IOPMP_t *iopmp,
-                                             uint32_t *entry_num,
-                                             bool lock)
+enum iopmp_error generic_lock_entries(IOPMP_t *iopmp, uint32_t *entry_num,
+                                      bool lock)
 {
     uint32_t entrylck;
     uint32_t __entry_num = *entry_num;
@@ -831,40 +727,18 @@ static enum iopmp_error generic_lock_entries(IOPMP_t *iopmp,
     return __entry_num == *entry_num ? IOPMP_OK : IOPMP_ERR_ILLEGAL_VALUE;
 }
 
-/**
- * \brief Set IOPMP ERR_CFG.l to lock ERR_CFG register
- *
- * \param[in] iopmp             The IOPMP instance to be set
- */
-static void generic_lock_err_cfg(IOPMP_t *iopmp)
+void generic_lock_err_cfg(IOPMP_t *iopmp)
 {
     write_err_cfg(iopmp, IOPMP_ERR_CFG_L_MASK, IOPMP_ERR_CFG_L_MASK);
 }
 
-/**
- * \brief Set IOPMP ERR_CFG.ie to enable/disable IOPMP global interrupt
- *
- * \param[in] iopmp             The IOPMP instance to be set
- * \param[in] enable            True to enable or false to disable
- */
-static void generic_set_global_intr(IOPMP_t *iopmp, bool enable)
+void generic_set_global_intr(IOPMP_t *iopmp, bool enable)
 {
     write_err_cfg(iopmp, IOPMP_ERR_CFG_IE_MASK,
                   (enable << IOPMP_ERR_CFG_IE_SHIFT));
 }
 
-/**
- * \brief Set IOPMP ERR_CFG.rs to suppress/express error response
- *
- * \param[in] iopmp             The IOPMP instance to be set
- * \param[in,out] suppress      True to suppress or false to express
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p suppress does not match
- *         the actual value. The actual value is output via \p suppress
- */
-static enum iopmp_error generic_set_global_err_resp(IOPMP_t *iopmp,
-                                                    bool *suppress)
+enum iopmp_error generic_set_global_err_resp(IOPMP_t *iopmp, bool *suppress)
 {
     uint32_t err_cfg;
     bool __suppress = *suppress;
@@ -878,16 +752,7 @@ static enum iopmp_error generic_set_global_err_resp(IOPMP_t *iopmp,
     return __suppress == *suppress ? IOPMP_OK : IOPMP_ERR_ILLEGAL_VALUE;
 }
 
-/**
- * \brief Set IOPMP message-signaled interrupts (MSI) enable/disable
- *
- * \param[in] iopmp             The IOPMP instance to be set
- * \param[in,out] enable        True to enable or false to disable
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if \p enable can not be written into \p iopmp
- */
-static enum iopmp_error generic_set_msi_sel(IOPMP_t *iopmp, bool *enable)
+enum iopmp_error generic_set_msi_sel(IOPMP_t *iopmp, bool *enable)
 {
     uint32_t err_cfg;
     bool __enable = *enable;
@@ -901,20 +766,8 @@ static enum iopmp_error generic_set_msi_sel(IOPMP_t *iopmp, bool *enable)
     return __enable == *enable ? IOPMP_OK : IOPMP_ERR_ILLEGAL_VALUE;
 }
 
-/**
- * \brief Set IOPMP message-signaled interrupts (MSI) information
- *
- * \param[in] iopmp             The IOPMP instance to be set
- * \param[in,out] msiaddr64     Input 64-bit MSI address. Output WARL value
- * \param[in,out] msidata       Input 11-bit MSI data. Output WARL value
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if \p msiaddr64 or \p msidata can not be
- *         written into \p iopmp
- */
-static enum iopmp_error generic_set_msi_info(IOPMP_t *iopmp,
-                                             uint64_t *msiaddr64,
-                                             uint16_t *msidata)
+enum iopmp_error generic_set_msi_info(IOPMP_t *iopmp, uint64_t *msiaddr64,
+                                      uint16_t *msidata)
 {
     uint32_t err_cfg, err_msiaddr, err_msiaddrh;
     uint32_t rb_err_msiaddr, rb_err_msiaddrh;
@@ -954,13 +807,7 @@ static enum iopmp_error generic_set_msi_info(IOPMP_t *iopmp,
            IOPMP_OK : IOPMP_ERR_ILLEGAL_VALUE;
 }
 
-/**
- * \brief Check if there is an MSI write error and clear the flag
- *
- * \param[in] iopmp             The IOPMP instance to be checked
- * \param[out] msi_werr         The pointer to flag
- */
-static void generic_get_and_clear_msi_werr(IOPMP_t *iopmp, bool *msi_werr)
+void generic_get_and_clear_msi_werr(IOPMP_t *iopmp, bool *msi_werr)
 {
     uint32_t err_info;
 
@@ -971,17 +818,6 @@ static void generic_get_and_clear_msi_werr(IOPMP_t *iopmp, bool *msi_werr)
     io_write32(iopmp->addr + IOPMP_ERR_INFO_BASE, IOPMP_ERR_INFO_MSI_WERR_MASK);
 }
 
-/**
- * \brief Set IOPMP ERR_CFG.stall_violation_en
- *
- * \param[in] iopmp             The IOPMP instance to be set
- * \param[in,out] enable        Input 1 to enable, 0 to disable. Output WARL
- *                              value
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if \p enable can't be written into \p iopmp
- */
-static
 enum iopmp_error generic_set_stall_violation_en(IOPMP_t *iopmp, bool *enable)
 {
     uint32_t err_cfg;
@@ -996,30 +832,15 @@ enum iopmp_error generic_set_stall_violation_en(IOPMP_t *iopmp, bool *enable)
     return __enable == *enable ? IOPMP_OK : IOPMP_ERR_ILLEGAL_VALUE;
 }
 
-/**
- * \brief Invalidate the error record by clearing ERR_INFO.v bit
- *
- * \param[in] iopmp             The IOPMP instance to be invalidated
- */
-static void generic_invalidate_error(IOPMP_t *iopmp)
+void generic_invalidate_error(IOPMP_t *iopmp)
 {
     /* Only ERR_INFO.ip is writable. Write 1 clear */
     io_write32(iopmp->addr + IOPMP_ERR_INFO_BASE, IOPMP_ERR_INFO_V_MASK);
 }
 
-/**
- * \brief Capture latest IOPMP error report
- *
- * \param[in] iopmp             The IOPMP instance to be captured
- * \param[out] err_report       The pointer to IOPMP error report structure
- * \param[in] invalidate        Flag to clear V bit after reading error report
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_NOT_EXIST if there is no an pending error
- */
-static enum iopmp_error generic_capture_error(IOPMP_t *iopmp,
-                                              IOPMP_ERR_REPORT_t *err_report,
-                                              bool invalidate)
+enum iopmp_error generic_capture_error(IOPMP_t *iopmp,
+                                       IOPMP_ERR_REPORT_t *err_report,
+                                       bool invalidate)
 {
     uint32_t err_reqaddr, err_reqaddrh, err_reqid, err_info;
 
@@ -1052,25 +873,8 @@ static enum iopmp_error generic_capture_error(IOPMP_t *iopmp,
     return IOPMP_OK;
 }
 
-/**
- * \brief Get subsequent violation window
- *
- * \param[in] iopmp             The IOPMP instance to be allocated
- * \param[in,out] svi           When calling, user can specify start index of
- *                              search windows. When this function returns with
- *                              IOPMP_OK, svi indicates the index of window
- *                              which has subsequent violation
- * \param[out] svw              When this function returns with IOPMP_OK, svw
- *                              indicates the content of window which has
- *                              subsequent violation
- *
- * \retval IOPMP_OK if at least one subsequent violation is found
- * \retval IOPMP_ERR_NOT_EXIST if there is no any subsequent violation
- *
- * \note Expected to be called after iopmp_capture_error() to get ERR_INFO.svc
- */
-static enum iopmp_error generic_get_sv_window(IOPMP_t *iopmp, uint16_t *svi,
-                                              uint16_t *svw)
+enum iopmp_error generic_get_sv_window(IOPMP_t *iopmp, uint16_t *svi,
+                                       uint16_t *svw)
 {
     uint32_t err_info;
     uint32_t err_mfr;
@@ -1546,32 +1350,6 @@ static enum iopmp_error sps_set_srcmd_x_64_md(IOPMP_t *iopmp, uint32_t rrid,
 /******************************************************************************/
 /* IOPMP operations for all well-defined models in IOPMP specification        */
 /******************************************************************************/
-/* Generic operations for all IOPMP models */
-static struct iopmp_operations_generic iopmp_operations_generic = {
-    .enable = generic_enable,
-    .lock_prio_entry_num = generic_lock_prio_entry_num,
-    .lock_rrid_transl = generic_lock_rrid_transl,
-    .set_prio_entry_num = generic_set_prio_entry_num,
-    .set_rrid_transl = generic_set_rrid_transl,
-    .stall_by_mds = generic_stall_by_mds,
-    .resume_transactions = generic_resume_transactions,
-    .poll_mdstall = generic_poll_mdstall,
-    .set_rridscp = generic_set_rridscp,
-    .lock_entries = generic_lock_entries,
-    .lock_err_cfg = generic_lock_err_cfg,
-    .set_global_intr = generic_set_global_intr,
-    .set_global_err_resp = generic_set_global_err_resp,
-    .set_msi_sel = generic_set_msi_sel,
-    .set_msi_info = generic_set_msi_info,
-    .get_and_clear_msi_werr = generic_get_and_clear_msi_werr,
-    .set_stall_violation_en = generic_set_stall_violation_en,
-    .capture_error = generic_capture_error,
-    .invalidate_error = generic_invalidate_error,
-    .get_sv_window = generic_get_sv_window,
-    .set_entries = generic_set_entries,
-    .get_entries = generic_get_entries,
-    .clear_entries = generic_clear_entries,
-};
 
 #ifdef ENABLE_SPS
 /* Operations specific to IOPMP/SPS extension */
@@ -1745,7 +1523,6 @@ __init_common(IOPMP_t *iopmp, uintptr_t addr,
         return ret;
 
     /* Setup operations */
-    iopmp->ops_generic = &iopmp_operations_generic;
     iopmp->ops_specific = ops_specific;
     if (!iopmp->ops_specific)
         return IOPMP_ERR_NOT_SUPPORTED;

--- a/libiopmp/src/iopmp_drv_common.c
+++ b/libiopmp/src/iopmp_drv_common.c
@@ -279,14 +279,12 @@ DECLARE_FUNC_GET_ADDR_OF_SRCMD(srcmd_en,    IOPMP_SRCMD_EN_BASE);
 DECLARE_FUNC_GET_ADDR_OF_SRCMD(srcmd_enh,   IOPMP_SRCMD_ENH_BASE);
 DECLARE_FUNC_GET_ADDR_OF_SRCMD(srcmd_perm,  IOPMP_SRCMD_PERM_BASE);
 DECLARE_FUNC_GET_ADDR_OF_SRCMD(srcmd_permh, IOPMP_SRCMD_PERMH_BASE);
-#ifdef ENABLE_SPS
 DECLARE_FUNC_GET_ADDR_OF_SRCMD(srcmd_r,     IOPMP_SRCMD_R_BASE);
 DECLARE_FUNC_GET_ADDR_OF_SRCMD(srcmd_rh,    IOPMP_SRCMD_RH_BASE);
 DECLARE_FUNC_GET_ADDR_OF_SRCMD(srcmd_w,     IOPMP_SRCMD_W_BASE);
 DECLARE_FUNC_GET_ADDR_OF_SRCMD(srcmd_wh,    IOPMP_SRCMD_WH_BASE);
 DECLARE_FUNC_GET_ADDR_OF_SRCMD(srcmd_x,     IOPMP_SRCMD_X_BASE);
 DECLARE_FUNC_GET_ADDR_OF_SRCMD(srcmd_xh,    IOPMP_SRCMD_XH_BASE);
-#endif
 
 /* Helper functions to read low 32-bit value from SRCMD registers */
 #define DECLARE_FUNC_READ_SRCMD_L(name)                                 \
@@ -296,11 +294,9 @@ static uint32_t read_ ## name(IOPMP_t *iopmp, uint32_t idx)             \
 }
 DECLARE_FUNC_READ_SRCMD_L(srcmd_en);
 DECLARE_FUNC_READ_SRCMD_L(srcmd_perm);
-#ifdef ENABLE_SPS
 DECLARE_FUNC_READ_SRCMD_L(srcmd_r);
 DECLARE_FUNC_READ_SRCMD_L(srcmd_w);
 DECLARE_FUNC_READ_SRCMD_L(srcmd_x);
-#endif
 
 /* Helper functions to read high 32-bit value from SRCMD registers */
 #define DECLARE_FUNC_READ_SRCMD_H(name, condition)                      \
@@ -312,11 +308,9 @@ static uint32_t read_ ## name(IOPMP_t *iopmp, uint32_t idx)             \
 }
 DECLARE_FUNC_READ_SRCMD_H(srcmd_enh,   (iopmp->md_num > 31));
 DECLARE_FUNC_READ_SRCMD_H(srcmd_permh, (iopmp->rrid_num > 16));
-#ifdef ENABLE_SPS
 DECLARE_FUNC_READ_SRCMD_H(srcmd_rh,    (iopmp->md_num > 31));
 DECLARE_FUNC_READ_SRCMD_H(srcmd_wh,    (iopmp->md_num > 31));
 DECLARE_FUNC_READ_SRCMD_H(srcmd_xh,    (iopmp->md_num > 31));
-#endif
 
 /* Helper functions to read 64-bit value from SRCMD registers */
 #define DECLARE_FUNC_READ_SRCMD_64(name)                                \
@@ -328,11 +322,9 @@ static uint64_t read_ ## name ## _64(IOPMP_t *iopmp, uint32_t idx)      \
 }
 DECLARE_FUNC_READ_SRCMD_64(srcmd_en);
 DECLARE_FUNC_READ_SRCMD_64(srcmd_perm);
-#ifdef ENABLE_SPS
 DECLARE_FUNC_READ_SRCMD_64(srcmd_r);
 DECLARE_FUNC_READ_SRCMD_64(srcmd_w);
 DECLARE_FUNC_READ_SRCMD_64(srcmd_x);
-#endif
 
 /* Helper functions to write low 32-bit value into SRCMD registers */
 #define DECLARE_FUNC_WRITE_SRCMD_L(name)                                \
@@ -342,11 +334,9 @@ static void write_ ## name(IOPMP_t *iopmp, uint32_t idx, uint32_t val)  \
 }
 DECLARE_FUNC_WRITE_SRCMD_L(srcmd_en);
 DECLARE_FUNC_WRITE_SRCMD_L(srcmd_perm);
-#ifdef ENABLE_SPS
 DECLARE_FUNC_WRITE_SRCMD_L(srcmd_r);
 DECLARE_FUNC_WRITE_SRCMD_L(srcmd_w);
 DECLARE_FUNC_WRITE_SRCMD_L(srcmd_x);
-#endif
 
 /* Helper functions to write high 32-bit value into SRCMD registers */
 #define DECLARE_FUNC_WRITE_SRCMD_H(name, condition)                     \
@@ -357,11 +347,9 @@ static void write_ ## name(IOPMP_t *iopmp, uint32_t idx, uint32_t val)  \
 }
 DECLARE_FUNC_WRITE_SRCMD_H(srcmd_enh,   (iopmp->md_num > 31));
 DECLARE_FUNC_WRITE_SRCMD_H(srcmd_permh, (iopmp->rrid_num > 16));
-#ifdef ENABLE_SPS
 DECLARE_FUNC_WRITE_SRCMD_H(srcmd_rh,    (iopmp->md_num > 31));
 DECLARE_FUNC_WRITE_SRCMD_H(srcmd_wh,    (iopmp->md_num > 31));
 DECLARE_FUNC_WRITE_SRCMD_H(srcmd_xh,    (iopmp->md_num > 31));
-#endif
 
 /* Helper functions to write 64-bit value into SRCMD registers */
 #define DECLARE_FUNC_WRITE_SRCMD_64(name)                               \
@@ -373,11 +361,9 @@ static void write_ ## name ## _64(IOPMP_t *iopmp, uint32_t idx,         \
 }
 DECLARE_FUNC_WRITE_SRCMD_64(srcmd_en);
 DECLARE_FUNC_WRITE_SRCMD_64(srcmd_perm);
-#ifdef ENABLE_SPS
 DECLARE_FUNC_WRITE_SRCMD_64(srcmd_r);
 DECLARE_FUNC_WRITE_SRCMD_64(srcmd_w);
 DECLARE_FUNC_WRITE_SRCMD_64(srcmd_x);
-#endif
 
 /* Helper functions to get base address of ENTRY registers */
 #define DECLARE_FUNC_GET_ADDR_OF_ENTRY(name, base)                      \
@@ -1213,41 +1199,16 @@ enum iopmp_error srcmd_fmt_2_mdcfg_fmt_1_md_entry_num_0_set_entries(
     return IOPMP_OK;
 }
 
-#ifdef ENABLE_SPS
 /******************************************************************************/
 /* Functions specific to IOPMP/SPS (Secondary Permission Setting) extension   */
 /******************************************************************************/
-/**
- * \brief Get RRID's read permission to MD(0) ~ MD(62)
- *
- * \param[in] iopmp             The IOPMP instance
- * \param[in] rrid              The RRID to be got
- *
- * \return SRCMD_RH(rrid).mdh | SRCMD_R(rrid).md
- *
- * \note This operation is only supported by IOPMP/SPS extension
- */
-static uint64_t sps_get_srcmd_r_64_md(IOPMP_t *iopmp, uint32_t rrid)
+uint64_t ext_sps_get_srcmd_r_64_md(IOPMP_t *iopmp, uint32_t rrid)
 {
     return read_srcmd_r_64(iopmp, rrid) >> IOPMP_SRCMD_R_MD_SHIFT;
 }
 
-/**
- * \brief Set RRID's read permission to MD(0) ~ MD(62)
- *
- * \param[in] iopmp             The IOPMP instance
- * \param[in] rrid              The RRID to be set
- * \param[in,out] mds           Input the read permission bitmap associated with
- *                              \p rrid. Output WARL value
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
- *         actual values
- *
- * \note This operation is only supported by IOPMP/SPS extension
- */
-static enum iopmp_error sps_set_srcmd_r_64_md(IOPMP_t *iopmp, uint32_t rrid,
-                                              uint64_t *mds)
+enum iopmp_error ext_sps_set_srcmd_r_64_md(IOPMP_t *iopmp, uint32_t rrid,
+                                           uint64_t *mds)
 {
     uint64_t srcmd_r_64;
     uint64_t __mds = *mds;
@@ -1255,42 +1216,18 @@ static enum iopmp_error sps_set_srcmd_r_64_md(IOPMP_t *iopmp, uint32_t rrid,
     srcmd_r_64 = __mds << IOPMP_SRCMD_R_MD_SHIFT;
     write_srcmd_r_64(iopmp, rrid, srcmd_r_64);
     /* SRCMD_R.md and SRCMD_RH.mdh are WARL. Read them back to check. */
-    *mds = sps_get_srcmd_r_64_md(iopmp, rrid);
+    *mds = ext_sps_get_srcmd_r_64_md(iopmp, rrid);
 
     return (*mds == __mds) ? IOPMP_OK : IOPMP_ERR_ILLEGAL_VALUE;
 }
 
-/**
- * \brief Get RRID's write permission to MD(0) ~ MD(62)
- *
- * \param[in] iopmp             The IOPMP instance
- * \param[in] rrid              The RRID to be got
- *
- * \return SRCMD_WH(rrid).mdh | SRCMD_W(rrid).md
- *
- * \note This operation is only supported by IOPMP/SPS extension
- */
-static uint64_t sps_get_srcmd_w_64_md(IOPMP_t *iopmp, uint32_t rrid)
+uint64_t ext_sps_get_srcmd_w_64_md(IOPMP_t *iopmp, uint32_t rrid)
 {
     return read_srcmd_w_64(iopmp, rrid) >> IOPMP_SRCMD_W_MD_SHIFT;
 }
 
-/**
- * \brief Set RRID's write permission to MD(0) ~ MD(62)
- *
- * \param[in] iopmp             The IOPMP instance
- * \param[in] rrid              The RRID to be set
- * \param[in,out] mds           Input the write permission bitmap associated
- *                              with \p rrid. Output WARL value
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
- *         actual values
- *
- * \note This operation is only supported by IOPMP/SPS extension
- */
-static enum iopmp_error sps_set_srcmd_w_64_md(IOPMP_t *iopmp, uint32_t rrid,
-                                              uint64_t *mds)
+enum iopmp_error ext_sps_set_srcmd_w_64_md(IOPMP_t *iopmp, uint32_t rrid,
+                                           uint64_t *mds)
 {
     uint64_t srcmd_w_64;
     uint64_t __mds = *mds;
@@ -1298,42 +1235,18 @@ static enum iopmp_error sps_set_srcmd_w_64_md(IOPMP_t *iopmp, uint32_t rrid,
     srcmd_w_64 = __mds << IOPMP_SRCMD_W_MD_SHIFT;
     write_srcmd_w_64(iopmp, rrid, srcmd_w_64);
     /* SRCMD_W.md and SRCMD_WH.mdh are WARL. Read them back to check. */
-    *mds = sps_get_srcmd_w_64_md(iopmp, rrid);
+    *mds = ext_sps_get_srcmd_w_64_md(iopmp, rrid);
 
     return (*mds == __mds) ? IOPMP_OK : IOPMP_ERR_ILLEGAL_VALUE;
 }
 
-/**
- * \brief Get RRID's instruction fetch permission to MD(0) ~ MD(62)
- *
- * \param[in] iopmp             The IOPMP instance
- * \param[in] rrid              The RRID to be got
- *
- * \return SRCMD_XH(rrid).mdh | SRCMD_X(rrid).md
- *
- * \note This operation is only supported by IOPMP/SPS extension
- */
-static uint64_t sps_get_srcmd_x_64_md(IOPMP_t *iopmp, uint32_t rrid)
+uint64_t ext_sps_get_srcmd_x_64_md(IOPMP_t *iopmp, uint32_t rrid)
 {
     return read_srcmd_x_64(iopmp, rrid) >> IOPMP_SRCMD_X_MD_SHIFT;
 }
 
-/**
- * \brief Set RRID's instruction fetch permission to MD(0) ~ MD(62)
- *
- * \param[in] iopmp             The IOPMP instance
- * \param[in] rrid              The RRID to be set
- * \param[in,out] mds           Input the instruction fetch permission bitmap
- *                              associated with \p rrid. Output WARL value
- *
- * \retval IOPMP_OK if successes
- * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
- *         actual values
- *
- * \note This operation is only supported by IOPMP/SPS extension
- */
-static enum iopmp_error sps_set_srcmd_x_64_md(IOPMP_t *iopmp, uint32_t rrid,
-                                              uint64_t *mds)
+enum iopmp_error ext_sps_set_srcmd_x_64_md(IOPMP_t *iopmp, uint32_t rrid,
+                                           uint64_t *mds)
 {
     uint64_t srcmd_x_64;
     uint64_t __mds = *mds;
@@ -1341,35 +1254,18 @@ static enum iopmp_error sps_set_srcmd_x_64_md(IOPMP_t *iopmp, uint32_t rrid,
     srcmd_x_64 = __mds << IOPMP_SRCMD_X_MD_SHIFT;
     write_srcmd_x_64(iopmp, rrid, srcmd_x_64);
     /* SRCMD_X.md and SRCMD_XH.mdh are WARL. Read them back to check. */
-    *mds = sps_get_srcmd_x_64_md(iopmp, rrid);
+    *mds = ext_sps_get_srcmd_x_64_md(iopmp, rrid);
 
     return (*mds == __mds) ? IOPMP_OK : IOPMP_ERR_ILLEGAL_VALUE;
 }
-#endif
-
-/******************************************************************************/
-/* IOPMP operations for all well-defined models in IOPMP specification        */
-/******************************************************************************/
-
-#ifdef ENABLE_SPS
-/* Operations specific to IOPMP/SPS extension */
-static struct iopmp_operations_sps iopmp_ops_sps = {
-    .sps_get_srcmd_r_64_md = sps_get_srcmd_r_64_md,
-    .sps_set_srcmd_r_64_md = sps_set_srcmd_r_64_md,
-    .sps_get_srcmd_w_64_md = sps_get_srcmd_w_64_md,
-    .sps_set_srcmd_w_64_md = sps_set_srcmd_w_64_md,
-    .sps_get_srcmd_x_64_md = sps_get_srcmd_x_64_md,
-    .sps_set_srcmd_x_64_md = sps_set_srcmd_x_64_md,
-};
-#endif
 
 /******************************************************************************/
 /* IOPMP common initialization for standard IOPMP implementation              */
 /******************************************************************************/
-static enum iopmp_error
-__init_common(IOPMP_t *iopmp, uintptr_t addr,
-              uint8_t srcmd_fmt, uint8_t mdcfg_fmt,
-              struct iopmp_operations_specific *ops_specific)
+enum iopmp_error
+iopmp_drv_init_common(IOPMP_t *iopmp, uintptr_t addr,
+                      uint8_t srcmd_fmt, uint8_t mdcfg_fmt,
+                      struct iopmp_operations_specific *ops_specific)
 {
     uint32_t data, hwcfg0, hwcfg3;
     uint8_t hwcfg3_srcmd_fmt, hwcfg3_mdcfg_fmt;
@@ -1526,36 +1422,7 @@ __init_common(IOPMP_t *iopmp, uintptr_t addr,
     iopmp->ops_specific = ops_specific;
     if (!iopmp->ops_specific)
         return IOPMP_ERR_NOT_SUPPORTED;
-    iopmp->ops_sps = NULL;
 
     iopmp->init = true;
     return IOPMP_OK;
 }
-
-#ifdef ENABLE_SPS
-enum iopmp_error
-iopmp_drv_init_common(IOPMP_t *iopmp, uintptr_t addr,
-                      uint8_t srcmd_fmt, uint8_t mdcfg_fmt,
-                      struct iopmp_operations_specific *ops_specific)
-{
-    enum iopmp_error ret;
-
-    ret = __init_common(iopmp, addr, srcmd_fmt, mdcfg_fmt, ops_specific);
-    if (ret != IOPMP_OK)
-        return ret;
-
-    /* Assign IOPMP/SPS operations */
-    if (iopmp->sps_en)
-        iopmp->ops_sps = &iopmp_ops_sps;
-
-    return IOPMP_OK;
-}
-#else
-enum iopmp_error
-iopmp_drv_init_common(IOPMP_t *iopmp, uintptr_t addr,
-                      uint8_t srcmd_fmt, uint8_t mdcfg_fmt,
-                      struct iopmp_operations_specific *ops_specific)
-{
-    return __init_common(iopmp, addr, srcmd_fmt, mdcfg_fmt, ops_specific);
-}
-#endif

--- a/libiopmp/src/iopmp_drv_common.c
+++ b/libiopmp/src/iopmp_drv_common.c
@@ -853,8 +853,14 @@ enum iopmp_error generic_capture_error(IOPMP_t *iopmp,
     err_report->etype = EXTRACT_FIELD(err_info, IOPMP_ERR_INFO_ETYPE);
     err_report->svc = EXTRACT_FIELD(err_info, IOPMP_ERR_INFO_SVC);
 
-    if (invalidate)
-        generic_invalidate_error(iopmp);
+    /* A driver may have replaced only invalidate_error, so honour it here */
+    if (invalidate) {
+        if (iopmp->ops_generic && iopmp->ops_generic->invalidate_error) {
+            iopmp->ops_generic->invalidate_error(iopmp);
+        } else {
+            generic_invalidate_error(iopmp);
+        }
+    }
 
     return IOPMP_OK;
 }

--- a/libiopmp/src/iopmp_drv_common.h
+++ b/libiopmp/src/iopmp_drv_common.h
@@ -165,41 +165,6 @@ iopmp_drv_init_common(IOPMP_t *iopmp, uintptr_t addr,
                       struct iopmp_operations_specific *ops_specific);
 
 /**
- * \brief Set the global entries into IOPMP
- *
- * \param[in] iopmp             The IOPMP instance to be written
- * \param[in] entry_array       The array of entries
- * \param[in] idx_start         The global start index of target entries
- * \param[in] num_entry         The number of entries to be written
- *
- * \return IOPMP_OK
- */
-enum iopmp_error generic_set_entries(IOPMP_t *iopmp,
-                                     const struct iopmp_entry *entry_array,
-                                     uint32_t idx_start, uint32_t num_entry);
-
-/**
- * \brief Get the global entries from IOPMP
- *
- * \param[in] iopmp             The IOPMP instance to be read
- * \param[out] entry_array      The array of entries
- * \param[in] idx_start         The global start index of target entries
- * \param[in] num_entry         The number of entries to be read
- */
-void generic_get_entries(IOPMP_t *iopmp, struct iopmp_entry *entry_array,
-                         uint32_t idx_start, uint32_t num_entry);
-
-/**
- * \brief Clear IOPMP entries
- *
- * \param[in] iopmp             The IOPMP instance
- * \param[in] idx_start         The start index of entries to be cleared
- * \param[in] num_entry         The number of entries to be cleared
- */
-void generic_clear_entries(IOPMP_t *iopmp, uint32_t idx_start,
-                           uint32_t num_entry);
-
-/**
  * \brief Get the associated MD bitmap and lock bit of given RRID
  *
  * \param[in] iopmp             The IOPMP instance to be got
@@ -413,5 +378,286 @@ srcmd_fmt_2_set_md_permission_multi(IOPMP_t *iopmp, uint32_t mdidx,
 enum iopmp_error srcmd_fmt_2_mdcfg_fmt_1_md_entry_num_0_set_entries(
     IOPMP_t *iopmp, const struct iopmp_entry *entry_array,
     uint32_t idx_start, uint32_t num_entry);
+
+/******************************************************************************/
+/* Generic operations, shared by every IOPMP model                            */
+/******************************************************************************/
+/*
+ * One implementation serves every model, so libiopmp calls these by name. A
+ * driver that has to replace one installs it in iopmp->ops_generic, which each
+ * call site tests first. See struct iopmp_operations_generic.
+ */
+/**
+ * \brief Capture latest IOPMP error report
+ *
+ * \param[in] iopmp             The IOPMP instance to be captured
+ * \param[out] err_report       The pointer to IOPMP error report structure
+ * \param[in] invalidate        Flag to clear V bit after reading error report
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_NOT_EXIST if there is no an pending error
+ */
+enum iopmp_error generic_capture_error(IOPMP_t *iopmp,
+                                       IOPMP_ERR_REPORT_t *err_report,
+                                       bool invalidate);
+
+/**
+ * \brief Clear IOPMP entries
+ *
+ * \param[in] iopmp             The IOPMP instance
+ * \param[in] idx_start         The start index of entries to be cleared
+ * \param[in] num_entry         The number of entries to be cleared
+ */
+void generic_clear_entries(IOPMP_t *iopmp, uint32_t idx_start,
+                           uint32_t num_entry);
+
+/**
+ * \brief Set the IOPMP HWCFG0.enable
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ */
+void generic_enable(IOPMP_t *iopmp);
+
+/**
+ * \brief Check if there is an MSI write error and clear the flag
+ *
+ * \param[in] iopmp             The IOPMP instance to be checked
+ * \param[out] msi_werr         The pointer to flag
+ */
+void generic_get_and_clear_msi_werr(IOPMP_t *iopmp, bool *msi_werr);
+
+/**
+ * \brief Get the global entries from IOPMP
+ *
+ * \param[in] iopmp             The IOPMP instance to be read
+ * \param[out] entry_array      The array of entries
+ * \param[in] idx_start         The global start index of target entries
+ * \param[in] num_entry         The number of entries to be read
+ */
+void generic_get_entries(IOPMP_t *iopmp, struct iopmp_entry *entry_array,
+                         uint32_t idx_start, uint32_t num_entry);
+
+/**
+ * \brief Get subsequent violation window
+ *
+ * \param[in] iopmp             The IOPMP instance to be allocated
+ * \param[in,out] svi           When calling, user can specify start index of
+ *                              search windows. When this function returns with
+ *                              IOPMP_OK, svi indicates the index of window
+ *                              which has subsequent violation
+ * \param[out] svw              When this function returns with IOPMP_OK, svw
+ *                              indicates the content of window which has
+ *                              subsequent violation
+ *
+ * \retval IOPMP_OK if at least one subsequent violation is found
+ * \retval IOPMP_ERR_NOT_EXIST if there is no any subsequent violation
+ *
+ * \note Expected to be called after iopmp_capture_error() to get ERR_INFO.svc
+ */
+enum iopmp_error generic_get_sv_window(IOPMP_t *iopmp, uint16_t *svi,
+                                       uint16_t *svw);
+
+/**
+ * \brief Invalidate the error record by clearing ERR_INFO.v bit
+ *
+ * \param[in] iopmp             The IOPMP instance to be invalidated
+ */
+void generic_invalidate_error(IOPMP_t *iopmp);
+
+/**
+ * \brief Lock ENTRY(0) ~ ENTRY(entry_num - 1)
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ * \param[in,out] entry_num     Input the number of entry to be locked. Output
+ *                              WARL value
+ * \param[in] lock              Lock ENTRYLCK register or not
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p entry_num does not match
+ *         the actual value. The actual value is output via \p entry_num
+ */
+enum iopmp_error generic_lock_entries(IOPMP_t *iopmp, uint32_t *entry_num,
+                                      bool lock);
+
+/**
+ * \brief Set IOPMP ERR_CFG.l to lock ERR_CFG register
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ */
+void generic_lock_err_cfg(IOPMP_t *iopmp);
+
+/**
+ * \brief Lock number of priority entry
+ *
+ * \param[in] iopmp             The IOPMP instance
+ */
+void generic_lock_prio_entry_num(IOPMP_t *iopmp);
+
+/**
+ * \brief Lock the RRID tagged to outgoing transactions
+ *
+ * \param[in] iopmp             The IOPMP instance
+ */
+void generic_lock_rrid_transl(IOPMP_t *iopmp);
+
+/**
+ * \brief Poll until MDSTALL.is_busy == 0
+ *
+ * \param[in] iopmp             The IOPMP instance to be checked
+ * \param[in] polling           Set true to poll the status until takes effect
+ * \param[in] stall_or_resume   Set true to poll for stall status or set false
+ *                              to poll for resume status
+ *
+ * \retval 1 if the previous operation has taken effect
+ * \retval 0 if the previous operation has not taken effect yet
+ */
+bool generic_poll_mdstall(IOPMP_t *iopmp, bool polling, bool stall_or_resume);
+
+/**
+ * \brief Resume the stalled transactions previously stalled, and poll the
+ * resume status until resuming takes effect if necessary
+ *
+ * \param[in] iopmp             The IOPMP instance to be resumed
+ * \param[in] polling           Set true to poll the resume status until
+ *                              resuming takes effect
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
+ *         actual value
+ */
+enum iopmp_error generic_resume_transactions(IOPMP_t *iopmp, bool polling);
+
+/**
+ * \brief Set the global entries into IOPMP
+ *
+ * \param[in] iopmp             The IOPMP instance to be written
+ * \param[in] entry_array       The array of entries
+ * \param[in] idx_start         The global start index of target entries
+ * \param[in] num_entry         The number of entries to be written
+ *
+ * \return IOPMP_OK
+ */
+enum iopmp_error generic_set_entries(IOPMP_t *iopmp,
+                                     const struct iopmp_entry *entry_array,
+                                     uint32_t idx_start, uint32_t num_entry);
+
+/**
+ * \brief Set IOPMP ERR_CFG.rs to suppress/express error response
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ * \param[in,out] suppress      True to suppress or false to express
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p suppress does not match
+ *         the actual value. The actual value is output via \p suppress
+ */
+enum iopmp_error generic_set_global_err_resp(IOPMP_t *iopmp, bool *suppress);
+
+/**
+ * \brief Set IOPMP ERR_CFG.ie to enable/disable IOPMP global interrupt
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ * \param[in] enable            True to enable or false to disable
+ */
+void generic_set_global_intr(IOPMP_t *iopmp, bool enable);
+
+/**
+ * \brief Set IOPMP message-signaled interrupts (MSI) information
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ * \param[in,out] msiaddr64     Input 64-bit MSI address. Output WARL value
+ * \param[in,out] msidata       Input 11-bit MSI data. Output WARL value
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if \p msiaddr64 or \p msidata can not be
+ *         written into \p iopmp
+ */
+enum iopmp_error generic_set_msi_info(IOPMP_t *iopmp, uint64_t *msiaddr64,
+                                      uint16_t *msidata);
+
+/**
+ * \brief Set IOPMP message-signaled interrupts (MSI) enable/disable
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ * \param[in,out] enable        True to enable or false to disable
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if \p enable can not be written into \p iopmp
+ */
+enum iopmp_error generic_set_msi_sel(IOPMP_t *iopmp, bool *enable);
+
+/**
+ * \brief Set IOPMP HWCFG2.prio_entry
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ * \param[in,out] num_entry     Input the number of entries to be matched with
+ *                              priority. Output WARL value.
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p num_entry does not match
+ *         the actual value. The actual value is output via \p num_entry
+ */
+enum iopmp_error generic_set_prio_entry_num(IOPMP_t *iopmp,
+                                            uint16_t *num_entry);
+
+/**
+ * \brief Write RRIDSCP with given RRID and operation
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ * \param[in,out] rrid          Input the RRID to be stalled. Output WARL value
+ * \param[in] op                The operation of RRIDSCP
+ * \param[out] stat             The pointer to store enum iopmp_rridscp_stat
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p rrid does not match the
+ *         actual value. The actual value is output via \p rrid
+ */
+enum iopmp_error generic_set_rridscp(IOPMP_t *iopmp, uint32_t *rrid,
+                                     enum iopmp_rridscp_op op,
+                                     enum iopmp_rridscp_stat *stat);
+
+/**
+ * \brief Set IOPMP HWCFG3.rrid_transl
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ * \param[in,out] rrid_transl   Input the value of rrid_transl to be set. Output
+ *                              WARL value
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p rrid_transl does not
+ *         match the actual value. The actual value is output via \p rrid_transl
+ */
+enum iopmp_error generic_set_rrid_transl(IOPMP_t *iopmp,
+                                         uint16_t *rrid_transl);
+
+/**
+ * \brief Set IOPMP ERR_CFG.stall_violation_en
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ * \param[in,out] enable        Input 1 to enable, 0 to disable. Output WARL
+ *                              value
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if \p enable can't be written into \p iopmp
+ */
+enum iopmp_error generic_set_stall_violation_en(IOPMP_t *iopmp, bool *enable);
+
+/**
+ * \brief Set MDSTALL to stall the transactions related to MDs bitmap, and poll
+ * the stall status until stall takes effect if necessary
+ *
+ * \param[in] iopmp             The IOPMP instance to be set
+ * \param[in,out] mds           Input the MD bitmap to be stalled. Output WARL
+ *                              value
+ * \param[in] exempt            Stall transactions with exempt selected MDs
+ * \param[in] polling           Set true to poll the stall status until stalling
+ *                              takes effect
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
+ *         actual value. The actual value is output via \p mds
+ */
+enum iopmp_error generic_stall_by_mds(IOPMP_t *iopmp, uint64_t *mds,
+                                      bool exempt, bool polling);
 
 #endif

--- a/libiopmp/src/iopmp_drv_common.h
+++ b/libiopmp/src/iopmp_drv_common.h
@@ -660,4 +660,94 @@ enum iopmp_error generic_set_stall_violation_en(IOPMP_t *iopmp, bool *enable);
 enum iopmp_error generic_stall_by_mds(IOPMP_t *iopmp, uint64_t *mds,
                                       bool exempt, bool polling);
 
+/******************************************************************************/
+/* SPS extension operations                                                   */
+/******************************************************************************/
+
+/**
+ * \brief Get RRID's read permission to MD(0) ~ MD(62)
+ *
+ * \param[in] iopmp             The IOPMP instance
+ * \param[in] rrid              The RRID to be got
+ *
+ * \return SRCMD_RH(rrid).mdh | SRCMD_R(rrid).md
+ *
+ * \note This operation is only supported by IOPMP/SPS extension
+ */
+uint64_t ext_sps_get_srcmd_r_64_md(IOPMP_t *iopmp, uint32_t rrid);
+
+/**
+ * \brief Set RRID's read permission to MD(0) ~ MD(62)
+ *
+ * \param[in] iopmp             The IOPMP instance
+ * \param[in] rrid              The RRID to be set
+ * \param[in,out] mds           Input the read permission bitmap associated with
+ *                              \p rrid. Output WARL value
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
+ *         actual values
+ *
+ * \note This operation is only supported by IOPMP/SPS extension
+ */
+enum iopmp_error ext_sps_set_srcmd_r_64_md(IOPMP_t *iopmp, uint32_t rrid,
+                                           uint64_t *mds);
+
+/**
+ * \brief Get RRID's write permission to MD(0) ~ MD(62)
+ *
+ * \param[in] iopmp             The IOPMP instance
+ * \param[in] rrid              The RRID to be got
+ *
+ * \return SRCMD_WH(rrid).mdh | SRCMD_W(rrid).md
+ *
+ * \note This operation is only supported by IOPMP/SPS extension
+ */
+uint64_t ext_sps_get_srcmd_w_64_md(IOPMP_t *iopmp, uint32_t rrid);
+
+/**
+ * \brief Set RRID's write permission to MD(0) ~ MD(62)
+ *
+ * \param[in] iopmp             The IOPMP instance
+ * \param[in] rrid              The RRID to be set
+ * \param[in,out] mds           Input the write permission bitmap associated
+ *                              with \p rrid. Output WARL value
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
+ *         actual values
+ *
+ * \note This operation is only supported by IOPMP/SPS extension
+ */
+enum iopmp_error ext_sps_set_srcmd_w_64_md(IOPMP_t *iopmp, uint32_t rrid,
+                                           uint64_t *mds);
+
+/**
+ * \brief Get RRID's instruction fetch permission to MD(0) ~ MD(62)
+ *
+ * \param[in] iopmp             The IOPMP instance
+ * \param[in] rrid              The RRID to be got
+ *
+ * \return SRCMD_XH(rrid).mdh | SRCMD_X(rrid).md
+ *
+ * \note This operation is only supported by IOPMP/SPS extension
+ */
+uint64_t ext_sps_get_srcmd_x_64_md(IOPMP_t *iopmp, uint32_t rrid);
+
+/**
+ * \brief Set RRID's instruction fetch permission to MD(0) ~ MD(62)
+ *
+ * \param[in] iopmp             The IOPMP instance
+ * \param[in] rrid              The RRID to be set
+ * \param[in,out] mds           Input the instruction fetch permission bitmap
+ *                              associated with \p rrid. Output WARL value
+ *
+ * \retval IOPMP_OK if successes
+ * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
+ *         actual values
+ *
+ * \note This operation is only supported by IOPMP/SPS extension
+ */
+enum iopmp_error ext_sps_set_srcmd_x_64_md(IOPMP_t *iopmp, uint32_t rrid,
+                                           uint64_t *mds);
 #endif

--- a/libiopmp/src/iopmp_drv_srcmd_fmt_2_mdcfg_fmt_1.c
+++ b/libiopmp/src/iopmp_drv_srcmd_fmt_2_mdcfg_fmt_1.c
@@ -32,6 +32,11 @@ struct iopmp_operations_specific iopmp_operations_srcmd_fmt_2_mdcfg_fmt_1 = {
     .lock_srcmd_table = srcmd_fmt_2_lock_srcmd_table,
 };
 
+/* K=1 makes every entry its own MD, so SRCMD_PERM(H) is written with it */
+static struct iopmp_operations_generic srcmd_fmt_2_mdcfg_fmt_1_k1_ops = {
+    .set_entries = srcmd_fmt_2_mdcfg_fmt_1_md_entry_num_0_set_entries,
+};
+
 const struct iopmp_driver iopmp_drv_srcmd_fmt_2_mdcfg_fmt_1;
 
 static enum iopmp_error
@@ -44,8 +49,7 @@ iopmp_drv_srcmd_fmt_2_mdcfg_fmt_1_init(IOPMP_t *iopmp, uintptr_t addr)
                                 iopmp_drv_srcmd_fmt_2_mdcfg_fmt_1.mdcfg_fmt,
                                 &iopmp_operations_srcmd_fmt_2_mdcfg_fmt_1);
     if (ret == IOPMP_OK && iopmp->md_entry_num == 0) {
-        iopmp->ops_generic->set_entries =
-                srcmd_fmt_2_mdcfg_fmt_1_md_entry_num_0_set_entries;
+        iopmp->ops_generic = &srcmd_fmt_2_mdcfg_fmt_1_k1_ops;
     }
 
     return ret;

--- a/libiopmp/src/libiopmp.c
+++ b/libiopmp/src/libiopmp.c
@@ -1214,6 +1214,35 @@ static enum iopmp_error __sps_check(IOPMP_t *iopmp, uint32_t rrid,
     return is_srcmd_en_locked ? IOPMP_ERR_REG_IS_LOCKED : IOPMP_OK;
 }
 
+/** The SRCMD_{R|W|X} register an SPS helper is to work on */
+enum iopmp_sps_perm {
+    IOPMP_SPS_PERM_R,
+    IOPMP_SPS_PERM_W,
+    IOPMP_SPS_PERM_X,
+};
+
+/**
+ * \brief (SPS only) Read SRCMD_{R|W|X}(rrid).md
+ *
+ * \param[in] iopmp             The IOPMP instance
+ * \param[in] rrid              The RRID to be got
+ * \param[in] perm              The permission to be got
+ *
+ * \return SRCMD_{R|W|X}(rrid).md
+ */
+static uint64_t __sps_read(IOPMP_t *iopmp, uint32_t rrid,
+                           enum iopmp_sps_perm perm)
+{
+    switch (perm) {
+    case IOPMP_SPS_PERM_R:
+        return ext_sps_get_srcmd_r_64_md(iopmp, rrid);
+    case IOPMP_SPS_PERM_W:
+        return ext_sps_get_srcmd_w_64_md(iopmp, rrid);
+    default:
+        return ext_sps_get_srcmd_x_64_md(iopmp, rrid);
+    }
+}
+
 /**
  * \brief (SPS only) Write one of SRCMD_{R|W|X}(rrid), assuming __sps_check()
  * has already accepted \p rrid, \p mds_set and \p mds_clr
@@ -1224,30 +1253,31 @@ static enum iopmp_error __sps_check(IOPMP_t *iopmp, uint32_t rrid,
  * \param[in] mds_clr           The desired MDs to clear permission to \p rrid
  * \param[out] mds              The pointer to an integer to store WARL value of
  *                              SRCMD_{R|W|X}.md after setting
- * \param[in] fp_get_srcmd_rwx_64   The function pointer to SPS operation to get
- *                                  value of SRCMD_{R|W|X}
- * \param[in] fp_set_srcmd_rwx_64   The function pointer to SPS operation to set
- *                                  value of SRCMD_{R|W|X}
+ * \param[in] perm              The permission to be set
  *
  * \retval IOPMP_OK if successes
  * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
  *         actual values
  */
-static enum iopmp_error __sps_apply(
-    IOPMP_t *iopmp, uint32_t rrid, uint64_t mds_set, uint64_t mds_clr,
-    uint64_t *mds, uint64_t (*fp_get_srcmd_rwx_64)(IOPMP_t *, uint32_t),
-    enum iopmp_error (*fp_set_srcmd_rwx_64)(IOPMP_t *, uint32_t , uint64_t *))
+static enum iopmp_error __sps_apply(IOPMP_t *iopmp, uint32_t rrid,
+                                    uint64_t mds_set, uint64_t mds_clr,
+                                    uint64_t *mds, enum iopmp_sps_perm perm)
 {
-    assert(fp_get_srcmd_rwx_64);
-    *mds = fp_get_srcmd_rwx_64(iopmp, rrid);
+    *mds = __sps_read(iopmp, rrid, perm);
 
     /* Set new MD bitmap */
     *mds |= mds_set;
     /* Clear new MD bitmap */
     *mds &= ~mds_clr;
 
-    assert(fp_set_srcmd_rwx_64);
-    return fp_set_srcmd_rwx_64(iopmp, rrid, mds);
+    switch (perm) {
+    case IOPMP_SPS_PERM_R:
+        return ext_sps_set_srcmd_r_64_md(iopmp, rrid, mds);
+    case IOPMP_SPS_PERM_W:
+        return ext_sps_set_srcmd_w_64_md(iopmp, rrid, mds);
+    default:
+        return ext_sps_set_srcmd_x_64_md(iopmp, rrid, mds);
+    }
 }
 
 /**
@@ -1259,10 +1289,7 @@ static enum iopmp_error __sps_apply(
  * \param[in] mds_clr           The desired MDs to clear permission to \p rrid
  * \param[out] mds              The pointer to an integer to store WARL value of
  *                              SRCMD_{R|W|X}.md after setting
- * \param[in] fp_get_srcmd_rwx_64   The function pointer to SPS operation to get
- *                                  value of SRCMD_{R|W|X}
- * \param[in] fp_set_srcmd_rwx_64   The function pointer to SPS operation to set
- *                                  value of SRCMD_{R|W|X}
+ * \param[in] perm              The permission to be set
  *
  * \retval IOPMP_OK if successes
  * \retval IOPMP_ERR_OUT_OF_BOUNDS if given \p rrid or \p mds is out of bounds
@@ -1271,10 +1298,9 @@ static enum iopmp_error __sps_apply(
  * \retval IOPMP_ERR_ILLEGAL_VALUE if the written \p mds does not match the
  *         actual values
  */
-static enum iopmp_error __sps_set(
-    IOPMP_t *iopmp, uint32_t rrid, uint64_t mds_set, uint64_t mds_clr,
-    uint64_t *mds, uint64_t (*fp_get_srcmd_rwx_64)(IOPMP_t *, uint32_t),
-    enum iopmp_error (*fp_set_srcmd_rwx_64)(IOPMP_t *, uint32_t , uint64_t *))
+static enum iopmp_error __sps_set(IOPMP_t *iopmp, uint32_t rrid,
+                                  uint64_t mds_set, uint64_t mds_clr,
+                                  uint64_t *mds, enum iopmp_sps_perm perm)
 {
     enum iopmp_error ret;
 
@@ -1288,8 +1314,7 @@ static enum iopmp_error __sps_set(
     if (ret != IOPMP_OK)
         return ret;
 
-    return __sps_apply(iopmp, rrid, mds_set, mds_clr, mds,
-                       fp_get_srcmd_rwx_64, fp_set_srcmd_rwx_64);
+    return __sps_apply(iopmp, rrid, mds_set, mds_clr, mds, perm);
 }
 
 /**
@@ -1298,16 +1323,14 @@ static enum iopmp_error __sps_set(
  * \param[in] iopmp             The IOPMP instance
  * \param[in] rrid              The RRID to be checked
  * \param[out] mds              Pointer to variable to output permission
- * \param[in] fp_get_srcmd_rwx_64   The function pointer to SPS operation to get
- *                                  value of SRCMD_{R|W|X}
+ * \param[in] perm              The permission to be got
  *
  * \retval IOPMP_OK if successes
  * \retval IOPMP_ERR_OUT_OF_BOUNDS if given \p rrid is out of bounds
  * \retval IOPMP_ERR_INVALID_PARAMETER if given \p mds is NULL
  */
-static
-enum iopmp_error __sps_get(IOPMP_t *iopmp, uint32_t rrid, uint64_t *mds,
-                           uint64_t (*fp_get_srcmd_rwx_64)(IOPMP_t *, uint32_t))
+static enum iopmp_error __sps_get(IOPMP_t *iopmp, uint32_t rrid, uint64_t *mds,
+                                  enum iopmp_sps_perm perm)
 {
     if (rrid >= iopmp->rrid_num)
         return IOPMP_ERR_OUT_OF_BOUNDS;
@@ -1315,8 +1338,7 @@ enum iopmp_error __sps_get(IOPMP_t *iopmp, uint32_t rrid, uint64_t *mds,
     if (!mds)
         return IOPMP_ERR_INVALID_PARAMETER;
 
-    assert(fp_get_srcmd_rwx_64);
-    *mds = fp_get_srcmd_rwx_64(iopmp, rrid);
+    *mds = __sps_read(iopmp, rrid, perm);
 
     return IOPMP_OK;
 }
@@ -1331,9 +1353,7 @@ enum iopmp_error iopmp_sps_set_rrid_md_read(IOPMP_t *iopmp, uint32_t rrid,
     if (!iopmp_get_support_sps(iopmp))
         return IOPMP_ERR_NOT_SUPPORTED;
 
-    return __sps_set(iopmp, rrid, mds_set, mds_clr, mds,
-                     iopmp->ops_sps->sps_get_srcmd_r_64_md,
-                     iopmp->ops_sps->sps_set_srcmd_r_64_md);
+    return __sps_set(iopmp, rrid, mds_set, mds_clr, mds, IOPMP_SPS_PERM_R);
 }
 
 enum iopmp_error iopmp_sps_get_rrid_md_read(IOPMP_t *iopmp, uint32_t rrid,
@@ -1344,7 +1364,7 @@ enum iopmp_error iopmp_sps_get_rrid_md_read(IOPMP_t *iopmp, uint32_t rrid,
     if (!iopmp_get_support_sps(iopmp))
         return IOPMP_ERR_NOT_SUPPORTED;
 
-    return __sps_get(iopmp, rrid, mds, iopmp->ops_sps->sps_get_srcmd_r_64_md);
+    return __sps_get(iopmp, rrid, mds, IOPMP_SPS_PERM_R);
 }
 
 enum iopmp_error iopmp_sps_set_rrid_md_write(IOPMP_t *iopmp, uint32_t rrid,
@@ -1357,9 +1377,7 @@ enum iopmp_error iopmp_sps_set_rrid_md_write(IOPMP_t *iopmp, uint32_t rrid,
     if (!iopmp_get_support_sps(iopmp))
         return IOPMP_ERR_NOT_SUPPORTED;
 
-    return __sps_set(iopmp, rrid, mds_set, mds_clr, mds,
-                     iopmp->ops_sps->sps_get_srcmd_w_64_md,
-                     iopmp->ops_sps->sps_set_srcmd_w_64_md);
+    return __sps_set(iopmp, rrid, mds_set, mds_clr, mds, IOPMP_SPS_PERM_W);
 }
 
 enum iopmp_error iopmp_sps_get_rrid_md_write(IOPMP_t *iopmp, uint32_t rrid,
@@ -1370,7 +1388,7 @@ enum iopmp_error iopmp_sps_get_rrid_md_write(IOPMP_t *iopmp, uint32_t rrid,
     if (!iopmp_get_support_sps(iopmp))
         return IOPMP_ERR_NOT_SUPPORTED;
 
-    return __sps_get(iopmp, rrid, mds, iopmp->ops_sps->sps_get_srcmd_w_64_md);
+    return __sps_get(iopmp, rrid, mds, IOPMP_SPS_PERM_W);
 }
 
 enum iopmp_error iopmp_sps_set_rrid_md_insn_fetch(IOPMP_t *iopmp, uint32_t rrid,
@@ -1383,9 +1401,7 @@ enum iopmp_error iopmp_sps_set_rrid_md_insn_fetch(IOPMP_t *iopmp, uint32_t rrid,
     if (!iopmp_get_support_sps(iopmp))
         return IOPMP_ERR_NOT_SUPPORTED;
 
-    return __sps_set(iopmp, rrid, mds_set, mds_clr, mds,
-                     iopmp->ops_sps->sps_get_srcmd_x_64_md,
-                     iopmp->ops_sps->sps_set_srcmd_x_64_md);
+    return __sps_set(iopmp, rrid, mds_set, mds_clr, mds, IOPMP_SPS_PERM_X);
 }
 
 enum iopmp_error iopmp_sps_get_rrid_md_insn_fetch(IOPMP_t *iopmp, uint32_t rrid,
@@ -1396,7 +1412,7 @@ enum iopmp_error iopmp_sps_get_rrid_md_insn_fetch(IOPMP_t *iopmp, uint32_t rrid,
     if (!iopmp_get_support_sps(iopmp))
         return IOPMP_ERR_NOT_SUPPORTED;
 
-    return __sps_get(iopmp, rrid, mds, iopmp->ops_sps->sps_get_srcmd_x_64_md);
+    return __sps_get(iopmp, rrid, mds, IOPMP_SPS_PERM_X);
 }
 
 enum iopmp_error iopmp_sps_set_rrid_md_rwx(IOPMP_t *iopmp, uint32_t rrid,
@@ -1432,20 +1448,17 @@ enum iopmp_error iopmp_sps_set_rrid_md_rwx(IOPMP_t *iopmp, uint32_t rrid,
         return ret;
 
     ret = __sps_apply(iopmp, rrid, mds_set_r, mds_clr_r, mds_r,
-                      iopmp->ops_sps->sps_get_srcmd_r_64_md,
-                      iopmp->ops_sps->sps_set_srcmd_r_64_md);
+                      IOPMP_SPS_PERM_R);
     if (ret != IOPMP_OK)
         return ret;
 
     ret = __sps_apply(iopmp, rrid, mds_set_w, mds_clr_w, mds_w,
-                      iopmp->ops_sps->sps_get_srcmd_w_64_md,
-                      iopmp->ops_sps->sps_set_srcmd_w_64_md);
+                      IOPMP_SPS_PERM_W);
     if (ret != IOPMP_OK)
         return ret;
 
     return __sps_apply(iopmp, rrid, mds_set_x, mds_clr_x, mds_x,
-                       iopmp->ops_sps->sps_get_srcmd_x_64_md,
-                       iopmp->ops_sps->sps_set_srcmd_x_64_md);
+                       IOPMP_SPS_PERM_X);
 }
 
 enum iopmp_error iopmp_sps_get_rrid_md_rwx(IOPMP_t *iopmp, uint32_t rrid,
@@ -1459,15 +1472,15 @@ enum iopmp_error iopmp_sps_get_rrid_md_rwx(IOPMP_t *iopmp, uint32_t rrid,
     if (!iopmp_get_support_sps(iopmp))
         return IOPMP_ERR_NOT_SUPPORTED;
 
-    ret = __sps_get(iopmp, rrid, mds_r, iopmp->ops_sps->sps_get_srcmd_r_64_md);
+    ret = __sps_get(iopmp, rrid, mds_r, IOPMP_SPS_PERM_R);
     if (ret != IOPMP_OK)
         return ret;
 
-    ret = __sps_get(iopmp, rrid, mds_w, iopmp->ops_sps->sps_get_srcmd_w_64_md);
+    ret = __sps_get(iopmp, rrid, mds_w, IOPMP_SPS_PERM_W);
     if (ret != IOPMP_OK)
         return ret;
 
-    return __sps_get(iopmp, rrid, mds_x, iopmp->ops_sps->sps_get_srcmd_x_64_md);
+    return __sps_get(iopmp, rrid, mds_x, IOPMP_SPS_PERM_X);
 }
 
 static inline void __get_md_entry_association_nocheck(IOPMP_t *iopmp,

--- a/libiopmp/src/libiopmp.c
+++ b/libiopmp/src/libiopmp.c
@@ -141,8 +141,11 @@ enum iopmp_error iopmp_lock_prio_entry_num(IOPMP_t *iopmp)
         return IOPMP_OK;
 
     /* If HWCFG2.prio_ent_prog is not wired to 0, this operation is mandatory */
-    assert(iopmp->ops_generic->lock_prio_entry_num);
-    iopmp->ops_generic->lock_prio_entry_num(iopmp);
+    if (iopmp->ops_generic && iopmp->ops_generic->lock_prio_entry_num) {
+        iopmp->ops_generic->lock_prio_entry_num(iopmp);
+    } else {
+        generic_lock_prio_entry_num(iopmp);
+    }
     iopmp->prio_ent_prog = false; /* update local cache */
 
     return IOPMP_OK;
@@ -161,8 +164,11 @@ enum iopmp_error iopmp_lock_rrid_transl(IOPMP_t *iopmp)
     /*
      * If HWCFG3.rrid_transl_prog is not wired to 0, this operation is mandatory
      */
-    assert(iopmp->ops_generic->lock_rrid_transl);
-    iopmp->ops_generic->lock_rrid_transl(iopmp);
+    if (iopmp->ops_generic && iopmp->ops_generic->lock_rrid_transl) {
+        iopmp->ops_generic->lock_rrid_transl(iopmp);
+    } else {
+        generic_lock_rrid_transl(iopmp);
+    }
     iopmp->rrid_transl_prog = false;    /* update local cache */
 
     return IOPMP_OK;
@@ -177,8 +183,11 @@ enum iopmp_error iopmp_set_enable(IOPMP_t *iopmp)
         return IOPMP_OK;
 
     /* HWCFG0.enable is mandatory W1SS bit */
-    assert(iopmp->ops_generic->enable);
-    iopmp->ops_generic->enable(iopmp);
+    if (iopmp->ops_generic && iopmp->ops_generic->enable) {
+        iopmp->ops_generic->enable(iopmp);
+    } else {
+        generic_enable(iopmp);
+    }
     iopmp->enable = true;   /* update local cache */
 
     return IOPMP_OK;
@@ -202,8 +211,11 @@ enum iopmp_error iopmp_set_prio_entry_num(IOPMP_t *iopmp, uint16_t *num_entry)
     /*
      * If HWCFG2.prio_ent_prog is not wired to 0, this operation is mandatory
      */
-    assert(iopmp->ops_generic->set_prio_entry_num);
-    ret = iopmp->ops_generic->set_prio_entry_num(iopmp, num_entry);
+    if (iopmp->ops_generic && iopmp->ops_generic->set_prio_entry_num) {
+        ret = iopmp->ops_generic->set_prio_entry_num(iopmp, num_entry);
+    } else {
+        ret = generic_set_prio_entry_num(iopmp, num_entry);
+    }
     /* HWCFG2.prio_entry is WARL field. We always update local cache for it */
     iopmp->prio_entry_num = *num_entry;
 
@@ -257,8 +269,11 @@ enum iopmp_error iopmp_set_rrid_transl(IOPMP_t *iopmp, uint16_t *rrid_transl)
     /*
      * If HWCFG3.rrid_transl_prog is not wired to 0, this operation is mandatory
      */
-    assert(iopmp->ops_generic->set_rrid_transl);
-    ret = iopmp->ops_generic->set_rrid_transl(iopmp, rrid_transl);
+    if (iopmp->ops_generic && iopmp->ops_generic->set_rrid_transl) {
+        ret = iopmp->ops_generic->set_rrid_transl(iopmp, rrid_transl);
+    } else {
+        ret = generic_set_rrid_transl(iopmp, rrid_transl);
+    }
     /* HWCFG3.rrid_transl is WARL field. We always update local cache for it */
     iopmp->rrid_transl = *rrid_transl;
 
@@ -298,8 +313,11 @@ enum iopmp_error iopmp_stall_transactions_by_mds(IOPMP_t *iopmp, uint64_t *mds,
         return IOPMP_ERR_ILLEGAL_VALUE;
     }
 
-    assert(iopmp->ops_generic->stall_by_mds);
-    ret = iopmp->ops_generic->stall_by_mds(iopmp, mds, exempt, polling);
+    if (iopmp->ops_generic && iopmp->ops_generic->stall_by_mds) {
+        ret = iopmp->ops_generic->stall_by_mds(iopmp, mds, exempt, polling);
+    } else {
+        ret = generic_stall_by_mds(iopmp, mds, exempt, polling);
+    }
     if (ret == IOPMP_OK)
         iopmp->is_stalling = true;
 
@@ -319,8 +337,11 @@ enum iopmp_error iopmp_resume_transactions(IOPMP_t *iopmp, bool polling)
     if (!iopmp->is_stalling)
         return IOPMP_ERR_NOT_ALLOWED;
 
-    assert(iopmp->ops_generic->resume_transactions);
-    ret = iopmp->ops_generic->resume_transactions(iopmp, polling);
+    if (iopmp->ops_generic && iopmp->ops_generic->resume_transactions) {
+        ret = iopmp->ops_generic->resume_transactions(iopmp, polling);
+    } else {
+        ret = generic_resume_transactions(iopmp, polling);
+    }
     if (ret == IOPMP_OK)
         iopmp->is_stalling = false;
 
@@ -340,8 +361,12 @@ static enum iopmp_error __iopmp_poll_mdstall(IOPMP_t *iopmp,
     if (!done)
         return IOPMP_ERR_INVALID_PARAMETER;
 
-    assert(iopmp->ops_generic->poll_mdstall);
-    *done = iopmp->ops_generic->poll_mdstall(iopmp, polling, stall_or_resume);
+    if (iopmp->ops_generic && iopmp->ops_generic->poll_mdstall) {
+        *done = iopmp->ops_generic->poll_mdstall(iopmp, polling,
+                                                 stall_or_resume);
+    } else {
+        *done = generic_poll_mdstall(iopmp, polling, stall_or_resume);
+    }
 
     return IOPMP_OK;
 }
@@ -381,13 +406,19 @@ enum iopmp_error iopmp_probe_stall_by_md(IOPMP_t *iopmp, uint64_t *mds)
     if (iopmp->is_stalling)
         return IOPMP_ERR_NOT_ALLOWED;
 
-    assert(iopmp->ops_generic->stall_by_mds);
     *mds = GENMASK_64((iopmp->md_num - 1), 0);
-    ret = iopmp->ops_generic->stall_by_mds(iopmp, mds, false, false);
+    if (iopmp->ops_generic && iopmp->ops_generic->stall_by_mds) {
+        ret = iopmp->ops_generic->stall_by_mds(iopmp, mds, false, false);
+    } else {
+        ret = generic_stall_by_mds(iopmp, mds, false, false);
+    }
     if (ret == IOPMP_OK) {
         /* Every MD was accepted, so undo the stall the probe just caused */
-        assert(iopmp->ops_generic->resume_transactions);
-        ret = iopmp->ops_generic->resume_transactions(iopmp, true);
+        if (iopmp->ops_generic && iopmp->ops_generic->resume_transactions) {
+            ret = iopmp->ops_generic->resume_transactions(iopmp, true);
+        } else {
+            ret = generic_resume_transactions(iopmp, true);
+        }
     } else if (ret == IOPMP_ERR_ILLEGAL_VALUE) {
         /* A narrower read-back is the answer, not a failure, and
          * stall_by_mds() has already resumed on our behalf */
@@ -431,8 +462,11 @@ static enum iopmp_error __iopmp_set_rridscp(IOPMP_t *iopmp, uint32_t *rrid,
     if (*rrid >= iopmp->rrid_num)
         return IOPMP_ERR_OUT_OF_BOUNDS;
 
-    assert(iopmp->ops_generic->set_rridscp);
-    return iopmp->ops_generic->set_rridscp(iopmp, rrid, op, stat);
+    if (iopmp->ops_generic && iopmp->ops_generic->set_rridscp) {
+        return iopmp->ops_generic->set_rridscp(iopmp, rrid, op, stat);
+    } else {
+        return generic_set_rridscp(iopmp, rrid, op, stat);
+    }
 }
 
 enum iopmp_error iopmp_stall_cherry_pick_rrid(IOPMP_t *iopmp, uint32_t *rrid,
@@ -600,9 +634,12 @@ enum iopmp_error iopmp_lock_entries(IOPMP_t *iopmp, uint32_t *entry_num,
         return IOPMP_ERR_NOT_ALLOWED;   /* Should be monotonically increased */
 
     /* ENTRYLCK is mandatory register */
-    assert(iopmp->ops_generic->lock_entries);
 
-    ret = iopmp->ops_generic->lock_entries(iopmp, entry_num, lock);
+    if (iopmp->ops_generic && iopmp->ops_generic->lock_entries) {
+        ret = iopmp->ops_generic->lock_entries(iopmp, entry_num, lock);
+    } else {
+        ret = generic_lock_entries(iopmp, entry_num, lock);
+    }
     iopmp->entrylck_lock = lock;
     iopmp->entrylck_f = *entry_num;
 
@@ -618,9 +655,12 @@ enum iopmp_error iopmp_lock_err_cfg(IOPMP_t *iopmp)
         return IOPMP_OK;
 
     /* ERR_CFG.l is mandatory W1SS bit */
-    assert(iopmp->ops_generic->lock_err_cfg);
 
-    iopmp->ops_generic->lock_err_cfg(iopmp);
+    if (iopmp->ops_generic && iopmp->ops_generic->lock_err_cfg) {
+        iopmp->ops_generic->lock_err_cfg(iopmp);
+    } else {
+        generic_lock_err_cfg(iopmp);
+    }
     iopmp->err_cfg_lock = true; /* update local cache */
 
     return IOPMP_OK;
@@ -639,9 +679,12 @@ enum iopmp_error iopmp_set_global_intr(IOPMP_t *iopmp, bool enable)
         return IOPMP_ERR_REG_IS_LOCKED;
 
     /* ERR_CFG.ie is mandatory RW bit */
-    assert(iopmp->ops_generic->set_global_intr);
 
-    iopmp->ops_generic->set_global_intr(iopmp, enable);
+    if (iopmp->ops_generic && iopmp->ops_generic->set_global_intr) {
+        iopmp->ops_generic->set_global_intr(iopmp, enable);
+    } else {
+        generic_set_global_intr(iopmp, enable);
+    }
     iopmp->intr_enable = enable;    /* update local cache */
 
     return IOPMP_OK;
@@ -668,10 +711,11 @@ enum iopmp_error iopmp_set_global_err_resp(IOPMP_t *iopmp, bool *suppress)
         return IOPMP_ERR_REG_IS_LOCKED;
 
     /* ERR_CFG.rs is optional */
-    if (!iopmp->ops_generic->set_global_err_resp)
-        return IOPMP_ERR_NOT_SUPPORTED;
-
-    ret = iopmp->ops_generic->set_global_err_resp(iopmp, suppress);
+    if (iopmp->ops_generic && iopmp->ops_generic->set_global_err_resp) {
+        ret = iopmp->ops_generic->set_global_err_resp(iopmp, suppress);
+    } else {
+        ret = generic_set_global_err_resp(iopmp, suppress);
+    }
     iopmp->err_resp_suppress = *suppress;   /* update local cache */
 
     return ret;
@@ -701,10 +745,11 @@ enum iopmp_error iopmp_set_msi_sel(IOPMP_t *iopmp, bool *enable)
         return IOPMP_ERR_REG_IS_LOCKED;
 
     /* ERR_CFG.msi_sel can be programmable or hardwired */
-    if (!iopmp->ops_generic->set_msi_sel)
-        return IOPMP_ERR_NOT_SUPPORTED;
-
-    ret = iopmp->ops_generic->set_msi_sel(iopmp, enable);
+    if (iopmp->ops_generic && iopmp->ops_generic->set_msi_sel) {
+        ret = iopmp->ops_generic->set_msi_sel(iopmp, enable);
+    } else {
+        ret = generic_set_msi_sel(iopmp, enable);
+    }
     iopmp->msi_sel = *enable;   /* update local cache */
 
     return ret;
@@ -777,8 +822,11 @@ enum iopmp_error iopmp_set_msi_info(IOPMP_t *iopmp, uint64_t *msiaddr64,
     if (iopmp->err_cfg_lock)
         return IOPMP_ERR_REG_IS_LOCKED;
 
-    assert(iopmp->ops_generic->set_msi_info);
-    ret = iopmp->ops_generic->set_msi_info(iopmp, msiaddr64, msidata);
+    if (iopmp->ops_generic && iopmp->ops_generic->set_msi_info) {
+        ret = iopmp->ops_generic->set_msi_info(iopmp, msiaddr64, msidata);
+    } else {
+        ret = generic_set_msi_info(iopmp, msiaddr64, msidata);
+    }
     /*
      * ERR_CFG.msidata, ERR_MSIADDR and ERR_MSIADDRH are WARL registers.
      * We need to always update local data cache for them.
@@ -800,8 +848,11 @@ enum iopmp_error iopmp_get_and_clear_msi_werr(IOPMP_t *iopmp, bool *msi_werr)
         return IOPMP_ERR_INVALID_PARAMETER;
 
     /* If HWCFG2.msi_en=1, this operation is mandatory */
-    assert(iopmp->ops_generic->get_and_clear_msi_werr);
-    iopmp->ops_generic->get_and_clear_msi_werr(iopmp, msi_werr);
+    if (iopmp->ops_generic && iopmp->ops_generic->get_and_clear_msi_werr) {
+        iopmp->ops_generic->get_and_clear_msi_werr(iopmp, msi_werr);
+    } else {
+        generic_get_and_clear_msi_werr(iopmp, msi_werr);
+    }
 
     return IOPMP_OK;
 }
@@ -826,8 +877,11 @@ enum iopmp_error iopmp_set_stall_violation_en(IOPMP_t *iopmp, bool *enable)
         return IOPMP_ERR_REG_IS_LOCKED;
 
     /* If HWCFG2.stall_en=1, this operation is mandatory */
-    assert(iopmp->ops_generic->set_stall_violation_en);
-    ret = iopmp->ops_generic->set_stall_violation_en(iopmp, enable);
+    if (iopmp->ops_generic && iopmp->ops_generic->set_stall_violation_en) {
+        ret = iopmp->ops_generic->set_stall_violation_en(iopmp, enable);
+    } else {
+        ret = generic_set_stall_violation_en(iopmp, enable);
+    }
     iopmp->stall_violation_en = *enable;
 
     return ret;
@@ -844,8 +898,11 @@ enum iopmp_error iopmp_invalidate_error(IOPMP_t *iopmp)
     if (iopmp->no_err_rec)
         return IOPMP_ERR_NOT_SUPPORTED;
 
-    assert(iopmp->ops_generic->invalidate_error);
-    iopmp->ops_generic->invalidate_error(iopmp);
+    if (iopmp->ops_generic && iopmp->ops_generic->invalidate_error) {
+        iopmp->ops_generic->invalidate_error(iopmp);
+    } else {
+        generic_invalidate_error(iopmp);
+    }
 
     return IOPMP_OK;
 }
@@ -862,8 +919,11 @@ enum iopmp_error iopmp_capture_error(IOPMP_t *iopmp,
     if (!err_report)
         return IOPMP_ERR_INVALID_PARAMETER;
 
-    assert(iopmp->ops_generic->capture_error);
-    return iopmp->ops_generic->capture_error(iopmp, err_report, invalidate);
+    if (iopmp->ops_generic && iopmp->ops_generic->capture_error) {
+        return iopmp->ops_generic->capture_error(iopmp, err_report, invalidate);
+    } else {
+        return generic_capture_error(iopmp, err_report, invalidate);
+    }
 }
 
 enum iopmp_error iopmp_mfr_get_sv_window(IOPMP_t *iopmp, uint16_t *svi,
@@ -878,8 +938,11 @@ enum iopmp_error iopmp_mfr_get_sv_window(IOPMP_t *iopmp, uint16_t *svi,
         return IOPMP_ERR_INVALID_PARAMETER;
 
     /* If HWCFG2.mfr_en=1, this operation is mandatory */
-    assert(iopmp->ops_generic->get_sv_window);
-    return iopmp->ops_generic->get_sv_window(iopmp, svi, svw);
+    if (iopmp->ops_generic && iopmp->ops_generic->get_sv_window) {
+        return iopmp->ops_generic->get_sv_window(iopmp, svi, svw);
+    } else {
+        return generic_get_sv_window(iopmp, svi, svw);
+    }
 }
 
 enum iopmp_error iopmp_lock_srcmd_table_fmt_0(IOPMP_t *iopmp, uint32_t rrid)
@@ -1835,9 +1898,12 @@ enum iopmp_error iopmp_set_entries(IOPMP_t *iopmp,
     if (idx_start < iopmp->entrylck_f)
         return IOPMP_ERR_REG_IS_LOCKED;
 
-    assert(iopmp->ops_generic->set_entries);
-    return iopmp->ops_generic->set_entries(iopmp, entry_array, idx_start,
-                                           num_entry);
+    if (iopmp->ops_generic && iopmp->ops_generic->set_entries) {
+        return iopmp->ops_generic->set_entries(iopmp, entry_array, idx_start,
+                                               num_entry);
+    } else {
+        return generic_set_entries(iopmp, entry_array, idx_start, num_entry);
+    }
 }
 
 enum iopmp_error iopmp_set_entries_to_md(IOPMP_t *iopmp, uint32_t mdidx,
@@ -1879,8 +1945,12 @@ enum iopmp_error iopmp_get_entries(IOPMP_t *iopmp,
         return IOPMP_ERR_OUT_OF_BOUNDS;
 
     /* Read IOPMP entries from IOPMP registers */
-    assert(iopmp->ops_generic->get_entries);
-    iopmp->ops_generic->get_entries(iopmp, entry_array, idx_start, num_entry);
+    if (iopmp->ops_generic && iopmp->ops_generic->get_entries) {
+        iopmp->ops_generic->get_entries(iopmp, entry_array, idx_start,
+                                        num_entry);
+    } else {
+        generic_get_entries(iopmp, entry_array, idx_start, num_entry);
+    }
 
     return IOPMP_OK;
 }
@@ -1926,8 +1996,11 @@ enum iopmp_error iopmp_clear_entries(IOPMP_t *iopmp, uint32_t idx_start,
     if (idx_start < iopmp->entrylck_f)
         return IOPMP_ERR_REG_IS_LOCKED;
 
-    assert(iopmp->ops_generic->clear_entries);
-    iopmp->ops_generic->clear_entries(iopmp, idx_start, num_entry);
+    if (iopmp->ops_generic && iopmp->ops_generic->clear_entries) {
+        iopmp->ops_generic->clear_entries(iopmp, idx_start, num_entry);
+    } else {
+        generic_clear_entries(iopmp, idx_start, num_entry);
+    }
 
     return IOPMP_OK;
 }

--- a/libiopmp/src/libiopmp_def.h
+++ b/libiopmp/src/libiopmp_def.h
@@ -167,23 +167,4 @@ struct iopmp_operations_specific {
                                          uint32_t *md_entry_num);
 };
 
-/** Structure represents the operations for SPS extension */
-struct iopmp_operations_sps {
-    /** Get 64-bit value of {SRCMD_RH(rrid), SRCMD_R(rrid)}.md */
-    uint64_t (*sps_get_srcmd_r_64_md)(IOPMP_t *iopmp, uint32_t rrid);
-    /** Set 64-bit value of {SRCMD_RH(rrid), SRCMD_R(rrid)}.md */
-    enum iopmp_error (*sps_set_srcmd_r_64_md)(IOPMP_t *iopmp, uint32_t rrid,
-                                              uint64_t *mds);
-    /** Get 64-bit value of {SRCMD_WH(rrid), SRCMD_W(rrid)}.md */
-    uint64_t (*sps_get_srcmd_w_64_md)(IOPMP_t *iopmp, uint32_t rrid);
-    /** Set 64-bit value of {SRCMD_WH(rrid), SRCMD_W(rrid)}.md */
-    enum iopmp_error (*sps_set_srcmd_w_64_md)(IOPMP_t *iopmp, uint32_t rrid,
-                                              uint64_t *mds);
-    /** Get 64-bit value of {SRCMD_XH(rrid), SRCMD_X(rrid)}.md */
-    uint64_t (*sps_get_srcmd_x_64_md)(IOPMP_t *iopmp, uint32_t rrid);
-    /** Set 64-bit value of {SRCMD_XH(rrid), SRCMD_X(rrid)}.md */
-    enum iopmp_error (*sps_set_srcmd_x_64_md)(IOPMP_t *iopmp, uint32_t rrid,
-                                              uint64_t *mds);
-};
-
 #endif  /* __LIBIOPMP_DEF_H__ */

--- a/libiopmp/src/libiopmp_def.h
+++ b/libiopmp/src/libiopmp_def.h
@@ -22,7 +22,21 @@
 /******************************************************************************/
 /* IOPMP operations                                                           */
 /******************************************************************************/
-/** Structure represents the generic operations for all the models */
+/**
+ * Structure represents the generic operations for all the models
+ *
+ * These act on the registers that chapters 2 to 4 of the specification make
+ * mandatory and define the same way for every model, so libiopmp implements
+ * each of them once and calls it by name. A driver that needs to replace one
+ * fills in the members that differ and points iopmp->ops_generic at the
+ * result; a member left NULL, and an instance whose ops_generic is NULL, keep
+ * the built-in implementation.
+ *
+ * The SRCMD_FMT=2/MDCFG_FMT=1 driver uses it to write SRCMD_PERM(H) alongside
+ * each entry when K=1. The other case is silicon built against a specification
+ * older than the one libiopmp targets, which can share an image with a
+ * conforming instance because the choice is made per instance, not per build.
+ */
 struct iopmp_operations_generic {
     /** Lock the number of priority entries. */
     void (*lock_prio_entry_num)(IOPMP_t *iopmp);


### PR DESCRIPTION
Now the interface calls driver operations directly instead of using default indirect call via operation tables.
Vendors can still override the operations via operation table if their IOPMP implements specific behaviors, see:

```c
static struct iopmp_operations_generic fake_ops_generic = {
    .set_global_intr = fake_set_global_intr,
};
```

SPS operation table is also removed.