### PR TITLE
spec: Fix images missing in the HTML build

### DIFF
--- a/application_note/iopmp_models.adoc
+++ b/application_note/iopmp_models.adoc
@@ -1,5 +1,8 @@
 === IOPMP Implementation Models
 
+ifdef::iopmp-spec-build[:imgpath: application_note/images]
+ifndef::iopmp-spec-build[:imgpath: images]
+
 The IOPMP specification supports multiple implementation models that combine different SRCMD Table and MDCFG Table formats to address specific system requirements. These models provide convenient reference configurations for common use cases, enabling designers to select appropriate trade-offs between hardware complexity, flexibility, and performance.
 
 ==== Full Model
@@ -26,12 +29,7 @@ The Rapid-k Model simplifies MDCFG Table lookup by implementing a fixed entry al
 *Use cases*: Systems with uniform memory region sizes, real-time systems requiring predictable access latency, applications with regular memory partitioning.
 
 .Block diagram of the Rapid-4 model implementation. The MDCFG Table is simplified to a constant mapping where each memory domain contains exactly four entries.
-ifdef::backend-pdf[]
-image::application_note/images/iopmp_unit_block_diagram_rapid_4.png[]
-endif::[]
-ifndef::backend-pdf[]
-image::images/iopmp_unit_block_diagram_rapid_4.png[]
-endif::[]
+image::{imgpath}/iopmp_unit_block_diagram_rapid_4.png[]
 
 ==== Dynamic-_k_ Model
 
@@ -86,11 +84,6 @@ The Compact-k Model maximizes area efficiency by combining both SRCMD and MDCFG 
 *Use cases*: Resource-constrained embedded systems, cost-sensitive applications, simple protection scenarios with isolated requesters and uniform memory regions.
 
 .Block diagram of the Compact-4 model implementation, combining SRCMD Format 1 and MDCFG Format 1 for maximum area efficiency.
-ifdef::backend-pdf[]
-image::application_note/images/iopmp_unit_block_diagram_compact_4.png[]
-endif::[]
-ifndef::backend-pdf[]
-image::images/iopmp_unit_block_diagram_compact_4.png[]
-endif::[]
+image::{imgpath}/iopmp_unit_block_diagram_compact_4.png[]
 
 These models serve as implementation guidelines, allowing system designers to choose configurations that best match their area constraints, performance requirements, and protection granularity needs. The selection involves trade-offs between hardware complexity, flexibility, isolation strength, and configuration overhead.

--- a/application_note/srcmd_reduction.adoc
+++ b/application_note/srcmd_reduction.adoc
@@ -1,6 +1,9 @@
 [#srcmd-table-formats]
 === SRCMD Table Reduction
 
+ifdef::iopmp-spec-build[:imgpath: images]
+ifndef::iopmp-spec-build[:imgpath: ../images]
+
 The IOPMP specification provides SRCMD Table reduction strategies to minimize hardware resource utilization in systems with simplified access control requirements. These strategies enable area-efficient implementations by reducing or eliminating SRCMD Table lookups while maintaining essential protection functionality.
 
 ==== Source-Enforcement
@@ -11,12 +14,7 @@ Source-enforcement is particularly beneficial in heterogeneous systems where som
 
 [#IOPMP_SE_Example]
 .Example implementation of source-enforcement where RISC-V harts use PMP while heterogeneous cores and DMA rely on IOPMP-SE.
-ifndef::backend-pdf[]
-image::../images/IOPMP_SE.drawio.png[]
-endif::[]
-ifdef::backend-pdf[]
-image::./images/IOPMP_SE.drawio.png[]
-endif::[]
+image::{imgpath}/IOPMP_SE.drawio.png[]
 
 ==== SRCMD Table in the Exclusive Format
 
@@ -41,12 +39,7 @@ For 0 &#x2264; _m_ &#x2264; 30, `MDLCK.md[_m_]` locks `SRCMD_PERM(_m_)` and `SRC
 
 [#Example_Format_2]
 .An example block diagram of SRCMD Table MD-indexed Format Implementation.
-ifdef::backend-pdf[]
-image::./images/srcmd_format2_example.png[]
-endif::[]
-ifndef::backend-pdf[]
-image::../images/srcmd_format2_example.png[]
-endif::[]
+image::{imgpath}/srcmd_format2_example.png[]
 
 `SRCMD_PERM(_m_)` and `SRCMD_PERMH(_m_)` are available when `HWCFG3.srcmd_fmt` = 2.
 In MD-indexed Format, an IOPMP checks both the permission of `SRCMD_PERM(H)(_m_)` and the `ENTRY_CFG.r/w/x` permission.

--- a/chapter2.adoc
+++ b/chapter2.adoc
@@ -126,7 +126,7 @@ Examples of implementation-dependent behaviors for handling improper MDCFG setti
 
 [NOTE]
 ====
-For portability, programmers should ensure the MDCFG Table has a proper setting during the runtime. In the case that the process of programming or initializing the MDCFG Table causes an improper setting to occur transiently, software can deassociate effected MDs in SRCMD table before programming MDCFG table to avoid security issues. Even though the procedure may introduce extra steps, the table is not subject to change at such a high frequency as to hurt overall performance. Thus, the specification requires programmers to maintain proper settings instead of requiring specific hardware behaviors on improper settings.
+For portability, programmers should ensure the MDCFG Table has a proper setting during the runtime. In the case that the process of programming or initializing the MDCFG Table causes an improper setting to occur transiently, software can deassociate affected MDs in SRCMD table before programming MDCFG table to avoid security issues. Even though the procedure may introduce extra steps, the table is not subject to change at such a high frequency as to hurt overall performance. Thus, the specification requires programmers to maintain proper settings instead of requiring specific hardware behaviors on improper settings.
 ====
 
 [#IOPMP_priority_and_matching_logic]

--- a/extensions/srcmd_extension.adoc
+++ b/extensions/srcmd_extension.adoc
@@ -1,6 +1,9 @@
 [#SPS_EXT]
 === Secondary Permission Setting (SPS)
 
+ifdef::iopmp-spec-build[:imgpath: images]
+ifndef::iopmp-spec-build[:imgpath: ../images]
+
 This extension provides a mechanism to reduce the consumption of IOPMP entries in systems where multiple requesters (RRIDs) require different access permissions to the same shared memory regions.
 
 Motivation: In the baseline specification, if RRID 'A' requires Read-Write (RW) access to a region and RRID 'B' requires Read-Only (RO) access to the exact same address range, two separate IOPMP entries must be configured (typically in two different Memory Domains). This consumes valuable Entry Array resources simply to define duplicate address ranges with different permissions.
@@ -16,12 +19,7 @@ Register `SRCMD_RH(_s_)`, `SRCMD_WH(_s_)`, `SRCMD_XH(_s_)` each has a single fie
 Register `SRCMD_RH(_s_)`, `SRCMD_WH(_s_)`, and `SRCMD_XH(_s_)` are implemented if `HWCFG0.md_num` > 31.
 
 .An example block diagram of an IOPMP with the SPS extension. It illustrates the checking flow of an IOPMP with the SPS extension. The IOPMP first looks up the SRCMD Table according to the RRID carried by the incoming transaction to retrieve associated MD indexes and the corresponding permissions related to these MDs. By the MD indexes, the IOPMP looks up the MDCFG Table to get the belonging entry indexes. The final step checks the access right according to the above entry indexes and corresponding permissions.
-ifdef::backend-pdf[]
-image::./images/iopmp_unit_block_diagram_other_formats.png[]
-endif::[]
-ifndef::backend-pdf[]
-image::../images/iopmp_unit_block_diagram_other_formats.png[]
-endif::[]
+image::{imgpath}/iopmp_unit_block_diagram_other_formats.png[]
 
 
 The extension shares the same locks as `SRCMD_EN(_s_)` and `SRCMD_ENH(_s_)`. Setting lock to `SRCMD_EN(_s_).l` locks `SRCMD_R(_s_)`, `SRCMD_RH(_s_)`, `SRCMD_W(_s_)`, `SRCMD_WH(_s_)`, `SRCMD_X(_s_)`, and `SRCMD_XH(_s_)`.

--- a/iopmp.adoc
+++ b/iopmp.adoc
@@ -10,6 +10,11 @@
 :colophon:
 :appendix-caption: Appendix
 :imagesdir: .
+// Marks the aggregate build. Included files use it to pick image paths that
+// are relative to this file's directory; without it (e.g. when a single
+// included file is previewed on its own) they fall back to paths relative to
+// their own directory. See {imgpath} in the included files.
+:iopmp-spec-build:
 :title-logo-image: image:./docs-resources/images/risc-v_logo.svg[pdfwidth=3.25in,align=center]
 // Settings:
 :experimental:


### PR DESCRIPTION
Fix the following wranings during "make" building process:

  asciidoctor: WARNING: image to embed not found or not readable: xxx/images/iopmp_unit_block_diagram_other_formats.png
  asciidoctor: WARNING: image to embed not found or not readable: xxx/images/IOPMP_SE.drawio.png
  asciidoctor: WARNING: image to embed not found or not readable: xxx/images/srcmd_format2_example.png
  asciidoctor: WARNING: image to embed not found or not readable: xxx/images/iopmp_unit_block_diagram_rapid_4.png
  asciidoctor: WARNING: image to embed not found or not readable: xxx/images/iopmp_unit_block_diagram_compact_4.png